### PR TITLE
feat: add more default relay lists

### DIFF
--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -14,6 +14,16 @@ import { Event } from 'nostr-tools'
 const DEFAULT_RELAY_SETS: TRelaySet[] = [
   {
     id: randomString(),
+    name: 'Short Notes',
+    relayUrls: ['wss://140.f7z.io/']
+  },
+  {
+    id: randomString(),
+    name: 'Safer Global',
+    relayUrls: ['wss://nostr.wine/', 'wss://pyramid.fiatjaf.com/']
+  },
+  {
+    id: randomString(),
     name: 'Global',
     relayUrls: ['wss://relay.damus.io/', 'wss://nos.lol/']
   },


### PR DESCRIPTION
just a suggestion.

it's sad we don't have a ton of weird relays to follow. but if we have I think the app should at least suggest them somehow. we will have more soon.

maybe christpill.nostr1.com is also something that can be used.