### PR TITLE
feat: add more default relay lists

### DIFF
--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -15,7 +15,7 @@ const DEFAULT_RELAY_SETS: TRelaySet[] = [
   {
     id: randomString(),
     name: 'Global',
-    relayUrls: ['wss://relay.damus.io/', 'wss://nos.lol/']
+    relayUrls: ['wss://relay.damus.io/', 'wss://nos.lol/', 'wss://jellyfish.land']
   },
   {
     id: randomString(),


### PR DESCRIPTION
Suggest adding `jellyfish` to the global default relays, it is trying to be in the best availability and performance.