### PR TITLE
fix: keep main feed scroll position on primary page navigation

### DIFF
--- a/src/layouts/PrimaryPageLayout/index.tsx
+++ b/src/layouts/PrimaryPageLayout/index.tsx
@@ -39,10 +39,21 @@ const PrimaryPageLayout = forwardRef(
       []
     )
 
+    const lastScrollTopRef = useRef(0)
     useEffect(() => {
       if (isSmallScreen) {
-        window.scrollTo({ top: 0 })
-        return
+        if (scrollAreaRef.current?.checkVisibility()) {
+          window.scrollTo({ top: lastScrollTopRef.current })
+        }
+        const handleScroll = () => {
+          if (scrollAreaRef.current?.checkVisibility()) {
+            lastScrollTopRef.current = window.scrollY
+          }
+        }
+        window.addEventListener('scroll', handleScroll)
+        return () => {
+          window.removeEventListener('scroll', handleScroll)
+        }
       }
     }, [current])
 
@@ -50,6 +61,7 @@ const PrimaryPageLayout = forwardRef(
       return (
         <DeepBrowsingProvider active={current === pageName}>
           <div
+            ref={scrollAreaRef}
             style={{
               paddingBottom: 'calc(env(safe-area-inset-bottom) + 3rem)'
             }}


### PR DESCRIPTION
fixes #57

I'm not sure why the ScrollArea component wasn't used for the small screens, but using this component fixed the persistent scroll behavior.

Please let me know if this shouldn't be used for mobile @CodyTseng 