### PR TITLE
feat: disable zap button on the user's own notes

### DIFF
--- a/src/components/NoteStats/ZapButton.tsx
+++ b/src/components/NoteStats/ZapButton.tsx
@@ -35,6 +35,7 @@ export default function ZapButton({ event }: { event: Event }) {
   useEffect(() => {
     client.fetchProfile(event.pubkey).then((profile) => {
       if (!profile) return
+      if (pubkey === profile.pubkey) return
       const lightningAddress = getLightningAddressFromProfile(profile)
       if (lightningAddress) setDisable(false)
     })


### PR DESCRIPTION
fixes #110

I think being able to react to our own post might be useful in some cases, for example if we want to have a reaction poll and submit our own vote to the poll by the reaction. At least I think it's not as pointless as zapping our own notes.

I just disabled the zap button, but let me know if you want the like/reaction button to be disabled as well @bitcoinuser @CodyTseng 