### PR TITLE
feat: handle app version and commit hash retrieval errors

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,29 @@ import path from 'path'
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 
+const getGitHash = () => {
+  try {
+    return JSON.stringify(execSync('git rev-parse --short HEAD').toString().trim())
+  } catch (error) {
+    console.warn('Failed to retrieve commit hash:', error)
+    return '"unknown"'
+  }
+}
+
+const getAppVersion = () => {
+  try {
+    return JSON.stringify(require('./package.json').version)
+  } catch (error) {
+    console.warn('Failed to retrieve app version:', error)
+    return '"unknown"'
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   define: {
-    __GIT_COMMIT__: JSON.stringify(execSync('git rev-parse --short HEAD').toString().trim()),
-    __APP_VERSION__: JSON.stringify(require('./package.json').version)
+    __GIT_COMMIT__: getGitHash(),
+    __APP_VERSION__: getAppVersion()
   },
   resolve: {
     alias: {


### PR DESCRIPTION
In some build environments, Git might not be present or may have insufficient permissions. In such cases, I think it's best to display a warning in the console but still allow the build to proceed with the "unknown" fallback value for the commit hash. I also added error handling for the app version, just in case.