### PR TITLE
fix: do not save secret

### DIFF
--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -412,10 +412,12 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     if (!loginResult.pubkey) {
       throw new Error('Invalid bunker')
     }
+    const bunkerUrl = new URL(loginResult.bunkerString!)
+    bunkerUrl.searchParams.delete('secret')
     return login(bunkerSigner, {
       pubkey: loginResult.pubkey,
       signerType: 'bunker',
-      bunker: loginResult.bunkerString!,
+      bunker: bunkerUrl.toString(),
       bunkerClientSecretKey: bunkerSigner.getClientSecretKey()
     })
   }


### PR DESCRIPTION
I'm submitting a PR to fix a bug where reconnection fails when logging in with client-generated connection tokens, which was recently merged.
As @CodyTseng  mentioned, storing the secret seems to be the cause. The two screenshots below show Amber's state when logged in with a Bunker-generated token versus a client-generated token. In the latter case, it appears Amber does not store the secret.

![11](https://github.com/user-attachments/assets/8fd57afd-f500-453e-b04f-928939aca548)
![22](https://github.com/user-attachments/assets/77298f24-a981-44aa-bf66-5a168f58ffd5)


The role of the secret is to verify the other party when a connection is established. Once a connection is made, both parties know each other's public keys, so the secret is no longer needed.
Therefore, I propose a modification to save the bunker string (NIP-46 connection string) by excluding the secret when it's stored.