### PR TITLE
add environment variables to set URLs in the docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VITE_PROXY_SERVER: http://localhost:8090
+        VITE_PROXY_SERVER: ${JUMBLE_PROXY_SERVER_URL:-http://localhost:8090} 
     ports:
       - "8089:80"
     restart: unless-stopped
@@ -17,7 +17,7 @@ services:
   proxy-server:
     image: ghcr.io/danvergara/jumble-proxy-server:latest
     environment:
-      - ALLOW_ORIGIN=http://localhost:8089
+      - ALLOW_ORIGIN=${JUMBLE_SOCIAL_URL:-http://localhost:8089}
       - PORT=8080
     ports:
       - "8090:8080"


### PR DESCRIPTION
Thought the Compose file was for development only, never thought it was used in production.

So I added some environment variables from the host to the Compose file with default values, so Docker can grab the production values from the server and we can keep testing the apps on our local machines.

Please set `JUMBLE_PROXY_SERVER_URL` and `JUMBLE_SOCIAL_URL` on the server.

Examples

```bash
export JUMBLE_SOCIAL_URL=https://jumble.social
export JUMBLE_PROXY_SERVER_URL=https://proxy.jumble.social
```

![Screenshot From 2025-06-14 10-37-18](https://github.com/user-attachments/assets/f1ff7274-6be2-4979-82d1-b9598a0dc29a)