### PR TITLE
reuse existing bunker connection on account switch

### DIFF
--- a/src/providers/NostrProvider/bunker.signer.ts
+++ b/src/providers/NostrProvider/bunker.signer.ts
@@ -12,7 +12,7 @@ export class BunkerSigner implements ISigner {
     this.clientSecretKey = clientSecretKey ? hexToBytes(clientSecretKey) : generateSecretKey()
   }
 
-  async login(bunker: string, isInitalLogin = true): Promise<string> {
+  async login(bunker: string, isInitialConnection = true): Promise<string> {
     const bunkerPointer = await parseBunkerInput(bunker)
     if (!bunkerPointer) {
       throw new Error('Invalid bunker')
@@ -23,7 +23,7 @@ export class BunkerSigner implements ISigner {
         window.open(url, '_blank')
       }
     })
-    if (isInitalLogin) {
+    if (isInitialConnection) {
       await this.signer.connect()
     }
     return await this.signer.getPublicKey()

--- a/src/providers/NostrProvider/bunker.signer.ts
+++ b/src/providers/NostrProvider/bunker.signer.ts
@@ -12,7 +12,7 @@ export class BunkerSigner implements ISigner {
     this.clientSecretKey = clientSecretKey ? hexToBytes(clientSecretKey) : generateSecretKey()
   }
 
-  async login(bunker: string): Promise<string> {
+  async login(bunker: string, isInitalLogin = true): Promise<string> {
     const bunkerPointer = await parseBunkerInput(bunker)
     if (!bunkerPointer) {
       throw new Error('Invalid bunker')
@@ -23,7 +23,9 @@ export class BunkerSigner implements ISigner {
         window.open(url, '_blank')
       }
     })
-    await this.signer.connect()
+    if (isInitalLogin) {
+      await this.signer.connect()
+    }
     return await this.signer.getPublicKey()
   }
 

--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -450,7 +450,7 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     } else if (account.signerType === 'bunker') {
       if (account.bunker && account.bunkerClientSecretKey) {
         const bunkerSigner = new BunkerSigner(account.bunkerClientSecretKey)
-        const pubkey = await bunkerSigner.login(account.bunker)
+        const pubkey = await bunkerSigner.login(account.bunker, false)
         if (!pubkey) {
           storage.removeAccount(account)
           return null


### PR DESCRIPTION
related to #387 

Previously, a new connect request was unnecessarily sent on every account switch or page refresh, even if a connection with the bunker was already active. 

This PR prevents the client from attempting to reconnect to a NIP-46 bunker every time the user switches to an account that already has an established connection.
