### PR TITLE
fix: bunker regex, add: addtitonal nostrconnect relay

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,4 +91,4 @@ export const NIP_96_SERVICE = [
 ]
 export const DEFAULT_NIP_96_SERVICE = 'https://nostr.build'
 
-export const DEFAULT_NOSTRCONNECT_RELAY = ['wss://relay.nsec.app/', 'wss://nos.lol/']
+export const DEFAULT_NOSTRCONNECT_RELAY = ['wss://relay.nsec.app/', 'wss://nos.lol/', 'wss://relay.primal.net']

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,4 +91,4 @@ export const NIP_96_SERVICE = [
 ]
 export const DEFAULT_NIP_96_SERVICE = 'https://nostr.build'
 
-export const DEFAULT_NOSTRCONNECT_RELAY = ['wss://relay.nsec.app/']
+export const DEFAULT_NOSTRCONNECT_RELAY = ['wss://relay.nsec.app/', 'wss://nos.lol/']

--- a/src/providers/NostrProvider/nip46.ts
+++ b/src/providers/NostrProvider/nip46.ts
@@ -6,7 +6,7 @@ import { decrypt, encrypt, getConversationKey } from "nostr-tools/nip44"
 import { RelayRecord } from "nostr-tools/relay"
 
 
-export const BUNKER_REGEX = /^bunker:\/\/([0-9a-f]{64})\??([?/w:.=&%-]*)$/
+export const BUNKER_REGEX = /^bunker:\/\/([0-9a-f]{64})\??([?/\w:.=&%-]*)$/
 
 // const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 


### PR DESCRIPTION
This PR resolves a critical bug in the BUNKER_REGEX and adds a new default relay to improve connection stability with bunkers.

The original regular expression for bunker:// URIs was inadvertently broken while trying to fix a no-useless-escape linting warning. This bug went unnoticed for a while because it wasn't triggered when using only the single default relay.

The issue was discovered when the primary default relay, wss://relay.nsec.app/, became unstable. While attempting to add and test a new relay to restore functionality, the faulty regex caused error, revealing the underlying problem.


Regex Correction: The BUNKER_REGEX has been restored to its correct, functional state. 
New Default Relay: A new, widely-used public relay has been added as a default to provide redundancy and ensure more reliable connections. 