### PR TITLE
Add a way to preview youtube links using iframes

### DIFF
--- a/src/components/WebPreview/index.tsx
+++ b/src/components/WebPreview/index.tsx
@@ -1,5 +1,6 @@
 import { useFetchWebMetadata } from '@/hooks/useFetchWebMetadata'
 import { cn } from '@/lib/utils'
+import { isYouTubeURL, extractVideoId, youtubeEmbdedURL } from '@/lib/url'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import { useMemo } from 'react'
 import Image from '../Image'
@@ -7,6 +8,11 @@ import Image from '../Image'
 export default function WebPreview({ url, className }: { url: string; className?: string }) {
   const { isSmallScreen } = useScreenSize()
   const { title, description, image } = useFetchWebMetadata(url)
+
+  // Check if it's a YouTube URL
+  const isYouTube = isYouTubeURL(url)
+  const videoId = isYouTube ? extractVideoId(url) : null
+
   const hostname = useMemo(() => {
     try {
       return new URL(url).hostname
@@ -14,6 +20,46 @@ export default function WebPreview({ url, className }: { url: string; className?
       return ''
     }
   }, [url])
+
+  // If it's a YouTube video with valid ID, render iframe
+  if (isYouTube && videoId) {
+    const embedUrl = youtubeEmbdedURL(videoId)
+
+    if (isSmallScreen) {
+      return (
+        <div className="rounded-lg border mt-2 overflow-hidden">
+          <iframe
+            src={embedUrl}
+            className="w-full h-44 rounded-t-lg"
+            allowFullScreen
+            title="YouTube video"
+          />
+          <div className="bg-muted p-2 w-full rounded-b-lg">
+            <div className="text-xs text-muted-foreground">youtube.com</div>
+            <div className="font-semibold line-clamp-1">{title || 'YouTube Video'}</div>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className={cn('border rounded-lg overflow-hidden', className)}>
+        <iframe
+          src={embedUrl}
+          className="w-full aspect-video"
+          allowFullScreen
+          title="YouTube video"
+        />
+        <div className="p-2">
+          <div className="text-xs text-muted-foreground">youtube.com</div>
+          <div className="font-semibold line-clamp-2">{title || 'YouTube Video'}</div>
+          {description && (
+            <div className="text-xs text-muted-foreground line-clamp-3">{description}</div>
+          )}
+        </div>
+      </div>
+    )
+  }
 
   if (!title) {
     return null

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -119,3 +119,33 @@ export function isVideo(url: string) {
     return false
   }
 }
+
+export function extractVideoId(url: string) {
+    const patterns = [
+        /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+        /youtube\.com\/watch\?.*v=([^&\n?#]+)/
+    ];
+    
+    for (const pattern of patterns) {
+        const match = url.match(pattern);
+        if (match) return match[1];
+    }
+    return null;
+}
+
+export function isYouTubeURL(url: string) {
+    if (!url || typeof url !== 'string') return false;
+    
+    const youtubePatterns = [
+        /^https?:\/\/(www\.)?youtube\.com\/watch\?.*v=[\w-]+/,
+        /^https?:\/\/youtu\.be\/[\w-]+/,
+        /^https?:\/\/(www\.)?youtube\.com\/embed\/[\w-]+/,
+        /^https?:\/\/m\.youtube\.com\/watch\?.*v=[\w-]+/
+    ];
+    
+    return youtubePatterns.some(pattern => pattern.test(url));
+}
+
+export function youtubeEmbdedURL(id: string) {
+    return `https://www.youtube.com/embed/${id}` 
+}


### PR DESCRIPTION
## Changes
* Add a bunch of helper functions to:
    *  determine if a url is youtube link
    * get the id from the url
    * parse an embed url using the id as parameter
 * Add youtube url handling in the WebPreview component returning an iframe if the url is in fact a youtube link

<img width="1717" height="832" alt="Screenshot From 2025-07-29 12-13-35" src="https://github.com/user-attachments/assets/f90d80a4-907d-41d5-bad2-9d02d3334060" />
<img width="727" height="742" alt="Screenshot From 2025-07-29 12-10-46" src="https://github.com/user-attachments/assets/b80100dc-4e04-45b6-9545-6d2039ab9141" />
