### PR TITLE
add: local relay(Citrine) for nostrconnect

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,7 @@ export const NIP_96_SERVICE = [
 export const DEFAULT_NIP_96_SERVICE = 'https://nostr.build'
 
 export const DEFAULT_NOSTRCONNECT_RELAY = [
+  'ws://127.0.0.1:4869/',
   'wss://relay.nsec.app/',
   'wss://nos.lol/',
   'wss://relay.primal.net'


### PR DESCRIPTION
https://jumble.social/notes/nevent1qvzqqqqqqypzprqgrf7tvq6w3gzkmltk6n4s7hxa6xzc0dgn7mrgr77cjs87svqzqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgwwaehxw309ahx7uewd3hkctcqyr5uqvzte8qpju05aqkjm0tfjzc8dhjv058fxp4apwpz9cesw4qwgwl5hre

This PR is proposed to mitigate the issue described in the linked note.

Considering @bitcoinuser  case, it appears the root cause of the nostrconnect instability is an unstable connection to the relays. If this is indeed the cause, I believe we can significantly reduce the problem by using a local relay.

Fortunately, there is a local relay called Citrine, created by the developer of Amber, which I was able to utilize. I have confirmed through logs that communication with the signer is now successfully routed through this local relay.

https://test.hoppe-relay.it.com/

While requiring a user to install an additional app besides the signer is not ideal from a UX perspective, the user in this case was already using Citrine. Furthermore, it should be rare for a user to experience such poor connectivity when three default relays are already in place.

There do not appear to be any issues for users who do not have Citrine installed.