### PR TITLE
added feature to completely hide muted replies and notes that reply to them

### DIFF
--- a/src/components/ContentPreview/index.tsx
+++ b/src/components/ContentPreview/index.tsx
@@ -1,6 +1,7 @@
 import { ExtendedKind } from '@/constants'
 import { cn } from '@/lib/utils'
 import { useMuteList } from '@/providers/MuteListProvider'
+import { useContentPolicy } from '@/providers/ContentPolicyProvider'
 import { Event, kinds } from 'nostr-tools'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -23,6 +24,7 @@ export default function ContentPreview({
 }) {
   const { t } = useTranslation()
   const { mutePubkeys } = useMuteList()
+  const { defaultShowMuted } = useContentPolicy()
   const isMuted = useMemo(
     () => (event ? mutePubkeys.includes(event.pubkey) : false),
     [mutePubkeys, event]
@@ -32,9 +34,10 @@ export default function ContentPreview({
     return <div className={cn('pointer-events-none', className)}>{`[${t('Note not found')}]`}</div>
   }
 
-  if (isMuted) {
+  if (isMuted && !defaultShowMuted) {
     return (
-      <div className={cn('pointer-events-none', className)}>[{t('This user has been muted')}]</div>
+      <div></div>
+      // <div className={cn('pointer-events-none', className)}>[{t('This user has been muted')}]</div>
     )
   }
 

--- a/src/components/ReplyNote/index.tsx
+++ b/src/components/ReplyNote/index.tsx
@@ -5,6 +5,7 @@ import { getUsingClient } from '@/lib/event'
 import { toNote } from '@/lib/link'
 import { useMuteList } from '@/providers/MuteListProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
+import { useContentPolicy } from '@/providers/ContentPolicyProvider'
 import { Event } from 'nostr-tools'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,12 +35,16 @@ export default function ReplyNote({
   const { isSmallScreen } = useScreenSize()
   const { push } = useSecondaryPage()
   const { mutePubkeys } = useMuteList()
+  const { defaultShowMuted } = useContentPolicy()
   const [showMuted, setShowMuted] = useState(false)
   const show = useMemo(
-    () => showMuted || !mutePubkeys.includes(event.pubkey),
-    [showMuted, mutePubkeys, event]
+    () => defaultShowMuted || showMuted || !mutePubkeys.includes(event.pubkey),
+    [defaultShowMuted, showMuted, mutePubkeys, event]
   )
   const usingClient = useMemo(() => getUsingClient(event), [event])
+  if (!showMuted && !show) return (
+    <div></div>
+  )
 
   return (
     <div

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export const StorageKey = {
   MEDIA_UPLOAD_SERVICE_CONFIG_MAP: 'mediaUploadServiceConfigMap',
   HIDE_UNTRUSTED_NOTES: 'hideUntrustedNotes',
   DEFAULT_SHOW_NSFW: 'defaultShowNsfw',
+  DEFAULT_SHOW_MUTED: 'defaultShowMuted',
   DISMISSED_TOO_MANY_RELAYS_ALERT: 'dismissedTooManyRelaysAlert',
   SHOW_KINDS: 'showKinds',
   SHOW_KINDS_VERSION: 'showKindsVersion',

--- a/src/pages/secondary/GeneralSettingsPage/index.tsx
+++ b/src/pages/secondary/GeneralSettingsPage/index.tsx
@@ -1,5 +1,10 @@
 import { Label } from '@/components/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { LocalizedLanguageNames, TLanguage } from '@/i18n'
 import SecondaryPageLayout from '@/layouts/SecondaryPageLayout'
@@ -16,7 +21,14 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
   const { t, i18n } = useTranslation()
   const [language, setLanguage] = useState<TLanguage>(i18n.language as TLanguage)
   const { themeSetting, setThemeSetting } = useTheme()
-  const { autoplay, setAutoplay, defaultShowNsfw, setDefaultShowNsfw } = useContentPolicy()
+  const {
+    autoplay,
+    setAutoplay,
+    defaultShowNsfw,
+    setDefaultShowNsfw,
+    defaultShowMuted,
+    setDefaultShowMuted
+  } = useContentPolicy()
   const { hideUntrustedNotes, updateHideUntrustedNotes } = useUserTrust()
 
   const handleLanguageChange = (value: TLanguage) => {
@@ -31,7 +43,8 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
           <Label htmlFor="languages" className="text-base font-normal">
             {t('Languages')}
           </Label>
-          <Select defaultValue="en" value={language} onValueChange={handleLanguageChange}>
+          <Select defaultValue="en" value={language}
+                  onValueChange={handleLanguageChange}>
             <SelectTrigger id="languages" className="w-48">
               <SelectValue />
             </SelectTrigger>
@@ -48,7 +61,8 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
           <Label htmlFor="theme" className="text-base font-normal">
             {t('Theme')}
           </Label>
-          <Select defaultValue="system" value={themeSetting} onValueChange={setThemeSetting}>
+          <Select defaultValue="system" value={themeSetting}
+                  onValueChange={setThemeSetting}>
             <SelectTrigger id="theme" className="w-48">
               <SelectValue />
             </SelectTrigger>
@@ -62,12 +76,15 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
         <SettingItem>
           <Label htmlFor="autoplay" className="text-base font-normal">
             <div>{t('Autoplay')}</div>
-            <div className="text-muted-foreground">{t('Enable video autoplay on this device')}</div>
+            <div
+              className="text-muted-foreground">{t('Enable video autoplay on this device')}</div>
           </Label>
-          <Switch id="autoplay" checked={autoplay} onCheckedChange={setAutoplay} />
+          <Switch id="autoplay" checked={autoplay}
+                  onCheckedChange={setAutoplay} />
         </SettingItem>
         <SettingItem>
-          <Label htmlFor="hide-untrusted-notes" className="text-base font-normal">
+          <Label htmlFor="hide-untrusted-notes"
+                 className="text-base font-normal">
             {t('Hide untrusted notes')}
           </Label>
           <Switch
@@ -80,7 +97,15 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
           <Label htmlFor="show-nsfw" className="text-base font-normal">
             {t('Show NSFW content by default')}
           </Label>
-          <Switch id="show-nsfw" checked={defaultShowNsfw} onCheckedChange={setDefaultShowNsfw} />
+          <Switch id="show-nsfw" checked={defaultShowNsfw}
+                  onCheckedChange={setDefaultShowNsfw} />
+        </SettingItem>
+        <SettingItem>
+          <Label htmlFor="show-muted" className="text-base font-normal">
+            {t('Display muted notes with discloser')}
+          </Label>
+          <Switch id="show-muted" checked={defaultShowMuted}
+                  onCheckedChange={setDefaultShowMuted} />
         </SettingItem>
         <SettingItem>
           <div>

--- a/src/providers/ContentPolicyProvider.tsx
+++ b/src/providers/ContentPolicyProvider.tsx
@@ -7,6 +7,8 @@ type TContentPolicyContext = {
 
   defaultShowNsfw: boolean
   setDefaultShowNsfw: (showNsfw: boolean) => void
+  defaultShowMuted: boolean
+  setDefaultShowMuted: (showMuted: boolean) => void
 }
 
 const ContentPolicyContext = createContext<TContentPolicyContext | undefined>(undefined)
@@ -22,7 +24,7 @@ export const useContentPolicy = () => {
 export function ContentPolicyProvider({ children }: { children: React.ReactNode }) {
   const [autoplay, setAutoplay] = useState<boolean>(storage.getAutoplay())
   const [defaultShowNsfw, setDefaultShowNsfw] = useState<boolean>(storage.getDefaultShowNsfw())
-
+  const [defaultShowMuted, setDefaultShowMuted]=useState<boolean>(storage.getDefaultShowMuted())
   const updateAutoplay = (autoplay: boolean) => {
     storage.setAutoplay(autoplay)
     setAutoplay(autoplay)
@@ -33,13 +35,20 @@ export function ContentPolicyProvider({ children }: { children: React.ReactNode 
     setDefaultShowNsfw(defaultShowNsfw)
   }
 
+  const updateDefaultShowMuted = (defaultShowMuted: boolean) => {
+    storage.setDefaultShowMuted(defaultShowMuted)
+    setDefaultShowMuted(defaultShowMuted)
+  }
+
   return (
     <ContentPolicyContext.Provider
       value={{
         autoplay,
         setAutoplay: updateAutoplay,
         defaultShowNsfw,
-        setDefaultShowNsfw: updateDefaultShowNsfw
+        setDefaultShowNsfw: updateDefaultShowNsfw,
+        defaultShowMuted,
+        setDefaultShowMuted: updateDefaultShowMuted,
       }}
     >
       {children}

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -33,6 +33,7 @@ class LocalStorageService {
   private translationServiceConfigMap: Record<string, TTranslationServiceConfig> = {}
   private mediaUploadServiceConfigMap: Record<string, TMediaUploadServiceConfig> = {}
   private defaultShowNsfw: boolean = false
+  private defaultShowMuted: boolean = true
   private dismissedTooManyRelaysAlert: boolean = false
   private showKinds: number[] = []
 
@@ -137,6 +138,9 @@ class LocalStorageService {
     }
 
     this.defaultShowNsfw = window.localStorage.getItem(StorageKey.DEFAULT_SHOW_NSFW) === 'true'
+    // default true when not set
+    const storedDefaultShowMuted = window.localStorage.getItem(StorageKey.DEFAULT_SHOW_MUTED)
+    this.defaultShowMuted = storedDefaultShowMuted ? storedDefaultShowMuted === 'true' : true
 
     this.dismissedTooManyRelaysAlert =
       window.localStorage.getItem(StorageKey.DISMISSED_TOO_MANY_RELAYS_ALERT) === 'true'
@@ -375,9 +379,18 @@ class LocalStorageService {
     return this.defaultShowNsfw
   }
 
+  getDefaultShowMuted() {
+    return this.defaultShowMuted
+  }
+
   setDefaultShowNsfw(defaultShowNsfw: boolean) {
     this.defaultShowNsfw = defaultShowNsfw
     window.localStorage.setItem(StorageKey.DEFAULT_SHOW_NSFW, defaultShowNsfw.toString())
+  }
+
+  setDefaultShowMuted(defaultShowMuted: boolean) {
+    this.defaultShowMuted = defaultShowMuted
+    window.localStorage.setItem(StorageKey.DEFAULT_SHOW_MUTED, defaultShowMuted.toString())
   }
 
   getDismissedTooManyRelaysAlert() {


### PR DESCRIPTION
I asked for this feature before, and mostly by myself without LLM help and then a little to finish adding the configuration item, jumble can now completely hide replies from muted npubs as well as hiding notes that reply to them.

i'm not sure what extra would be needed to add this to the user's application specific data event but even just to be able to turn it off in a browser session is enough. let me know if i need to also add this setting to the configuration data.