### PR TITLE
show stats on timeline

### DIFF
--- a/src/components/NoteCard/MainNoteCard.tsx
+++ b/src/components/NoteCard/MainNoteCard.tsx
@@ -40,7 +40,7 @@ export default function MainNoteCard({
             originalNoteId={originalNoteId}
           />
         </Collapsible>
-        {!embedded && <NoteStats className="mt-3 px-4" event={event} />}
+        {!embedded && <NoteStats className="mt-3 px-4" event={event} displayTopZapsAndLikes={false} fetchIfNotExisting={true} />}
       </div>
       {!embedded && <Separator />}
     </div>


### PR DESCRIPTION
## Changes
- Add the way to show the count of reactions, quotes and zaps on the timeline, without the top likes and zaps to show engagement numbers to the user.

<img width="1054" height="539" alt="Screenshot From 2025-09-05 13-38-53" src="https://github.com/user-attachments/assets/40d2b69f-4b73-4152-b287-2d3215041922" />
