### PR TITLE
Get GIT_COMMIT and APP_VERSION from import.meta.env

### DIFF
--- a/src/pages/secondary/SettingsPage/index.tsx
+++ b/src/pages/secondary/SettingsPage/index.tsx
@@ -116,7 +116,7 @@ const SettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
           </div>
           <div className="flex gap-2 items-center">
             <div className="text-muted-foreground">
-              v{__APP_VERSION__} ({__GIT_COMMIT__})
+              v{import.meta.env.APP_VERSION} ({import.meta.env.GIT_COMMIT})
             </div>
             <ChevronRight />
           </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,4 @@ declare global {
   interface Window {
     nostr?: TNip07
   }
-
-  const __GIT_COMMIT__: string
-  const __APP_VERSION__: string
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,8 +26,8 @@ const getAppVersion = () => {
 // https://vite.dev/config/
 export default defineConfig({
   define: {
-    __GIT_COMMIT__: getGitHash(),
-    __APP_VERSION__: getAppVersion()
+    'import.meta.env.GIT_COMMIT': getGitHash(),
+    'import.meta.env.APP_VERSION': getAppVersion()
   },
   resolve: {
     alias: {


### PR DESCRIPTION
`import.meta.env` is a cleaner way to define the commit and version strings. 

This fixes a runtime error when Jumble is [built with Shakespeare](https://gleasonator.dev/@alex@gleasonator.dev/posts/0e1edff846395a1ab5f8e2feec23396a3c83e5e22bfea53569ab20ca02620d66)!