### PR TITLE
Normalize pasted mentions and preview

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'dev-dist'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/PostEditor/PostTextarea/Preview.tsx
+++ b/src/components/PostEditor/PostTextarea/Preview.tsx
@@ -1,14 +1,56 @@
 import { Card } from '@/components/ui/card'
 import { transformCustomEmojisInContent } from '@/lib/draft-event'
+import { extractNostrReferences, normalizeNostrReferences } from '@/lib/nostr'
 import { createFakeEvent } from '@/lib/event'
 import { cn } from '@/lib/utils'
-import { useMemo } from 'react'
+import client from '@/services/client.service'
+import { useEffect, useMemo, useRef } from 'react'
 import Content from '../../Content'
 
 export default function Preview({ content, className }: { content: string; className?: string }) {
+  const normalizedContent = useMemo(() => normalizeNostrReferences(content), [content])
+  const mentionIdentifiers = useMemo(
+    () => extractNostrReferences(normalizedContent),
+    [normalizedContent]
+  )
+  const prefetchedMentionsRef = useRef<Set<string>>(new Set())
+  const prefetchedInFlightRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (mentionIdentifiers.length === 0) return
+
+    // Prefetch mention profiles so the preview can render resolved usernames.
+    mentionIdentifiers.forEach((identifier) => {
+      if (!identifier.startsWith('npub1') && !identifier.startsWith('nprofile1')) {
+        return
+      }
+      if (
+        prefetchedMentionsRef.current.has(identifier) ||
+        prefetchedInFlightRef.current.has(identifier)
+      ) {
+        return
+      }
+      prefetchedInFlightRef.current.add(identifier)
+
+      void (async () => {
+        try {
+          const profile = await client.fetchProfile(identifier)
+          if (!profile?.original_username) {
+            await client.fetchProfile(identifier, true)
+          }
+        } catch {
+          // ignore
+        } finally {
+          prefetchedInFlightRef.current.delete(identifier)
+          prefetchedMentionsRef.current.add(identifier)
+        }
+      })()
+    })
+  }, [mentionIdentifiers])
+
   const { content: processedContent, emojiTags } = useMemo(
-    () => transformCustomEmojisInContent(content),
-    [content]
+    () => transformCustomEmojisInContent(normalizedContent),
+    [normalizedContent]
   )
   return (
     <Card className={cn('p-3', className)}>

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -1,0 +1,32 @@
+import { nip19 } from 'nostr-tools'
+
+export const ENCODED_IDENTIFIER_REGEX =
+  /(^|\s|@)(?:nostr:)?((?:nevent|naddr|nprofile|npub)1[a-zA-Z0-9]+)/g
+
+export function normalizeNostrReferences(value: string) {
+  return value.replace(ENCODED_IDENTIFIER_REGEX, (match, prefix: string, identifier: string) => {
+    if (!identifier) return match
+
+    try {
+      nip19.decode(identifier)
+      const normalizedPrefix = prefix === '@' ? '' : prefix
+      return `${normalizedPrefix}nostr:${identifier}`
+    } catch {
+      return match
+    }
+  })
+}
+
+export function extractNostrReferences(value: string) {
+  const matches = value.matchAll(ENCODED_IDENTIFIER_REGEX)
+  const identifiers = new Set<string>()
+
+  for (const match of matches) {
+    const identifier = match[2]
+    if (identifier) {
+      identifiers.add(identifier)
+    }
+  }
+
+  return Array.from(identifiers)
+}

--- a/src/lib/tiptap.ts
+++ b/src/lib/tiptap.ts
@@ -1,23 +1,11 @@
 import customEmojiService from '@/services/custom-emoji.service'
 import { emojis, shortcodeToEmoji } from '@tiptap/extension-emoji'
 import { JSONContent } from '@tiptap/react'
-import { nip19 } from 'nostr-tools'
+import { normalizeNostrReferences } from './nostr'
 
 export function parseEditorJsonToText(node?: JSONContent) {
   const text = _parseEditorJsonToText(node).trim()
-  const regex = /(?:^|\s)(nevent|naddr|nprofile|npub)1[a-zA-Z0-9]+/g
-
-  return text.replace(regex, (match) => {
-    const trimmed = match.trim()
-    const leadingSpace = match.startsWith(' ') ? ' ' : ''
-
-    try {
-      nip19.decode(trimmed)
-      return `${leadingSpace}nostr:${trimmed}`
-    } catch {
-      return match
-    }
-  })
+  return normalizeNostrReferences(text)
 }
 
 function _parseEditorJsonToText(node?: JSONContent): string {


### PR DESCRIPTION
## Summary
  - normalize @npub/@nprofile mentions before serializing posts
  - share a normalization helper so the editor preview matches the
  published note
  - prefetch mention profiles so the preview resolves usernames
  instead of truncated npubs

## closes: https://github.com/CodyTseng/jumble/issues/624

## TESTING
[X] functional testing PASSED

## Proof

<img width="752" height="464" alt="image" src="https://github.com/user-attachments/assets/5082ce6d-db9c-4040-a4ce-eae265b721b3" />
<img width="742" height="462" alt="image" src="https://github.com/user-attachments/assets/1c09ab23-3937-47d0-afbb-77175afb9559" />
<img width="1089" height="321" alt="image" src="https://github.com/user-attachments/assets/7bd24d2f-f3cf-4628-8b74-ca5e14063d3e" />
