### PR TITLE
fix: preserve linebreaks between URLs and Nostr references in editor

### DIFF
--- a/src/lib/tiptap.ts
+++ b/src/lib/tiptap.ts
@@ -4,12 +4,13 @@ import { JSONContent } from '@tiptap/react'
 import { nip19 } from 'nostr-tools'
 
 export function parseEditorJsonToText(node?: JSONContent) {
-  const text = _parseEditorJsonToText(node).trim()
-  const regex = /(?:^|\s|@)(nostr:)?(nevent|naddr|nprofile|npub)1[a-zA-Z0-9]+/g
+  const text = _parseEditorJsonToText(node)
+  const regex = /(^|\s+|@)(nostr:)?(nevent|naddr|nprofile|npub)1[a-zA-Z0-9]+/g
 
-  return text.replace(regex, (match) => {
+  return text.replace(regex, (match, leadingWhitespace) => {
     let bech32 = match.trim()
-    const leadingSpace = match.startsWith(' ') ? ' ' : ''
+    const whitespace = leadingWhitespace || ''
+
     if (bech32.startsWith('@nostr:')) {
       bech32 = bech32.slice(7)
     } else if (bech32.startsWith('@')) {
@@ -20,11 +21,11 @@ export function parseEditorJsonToText(node?: JSONContent) {
 
     try {
       nip19.decode(bech32)
-      return `${leadingSpace}nostr:${bech32}`
+      return `${whitespace}nostr:${bech32}`
     } catch {
       return match
     }
-  })
+  }).trim()
 }
 
 function _parseEditorJsonToText(node?: JSONContent): string {


### PR DESCRIPTION
  The editor was removing linebreaks when serializing content containing URLs followed by Nostr references (nevent, naddr, etc). This caused notes to render incorrectly in other clients.

  Changed the parseEditorJsonToText function to:
  - Capture and preserve all whitespace (including newlines) before Nostr refs
  - Use regex capturing group to maintain original formatting
  - Only trim the final output instead of intermediate text

  Fixes [#656](https://github.com/CodyTseng/jumble/issues/656)