### PR TITLE
Bug fix for lnurl callback URLs that contain a ?

### DIFF
--- a/src/services/lightning.service.ts
+++ b/src/services/lightning.service.ts
@@ -73,8 +73,9 @@ class LightningService {
       comment
     })
     const zapRequest = await client.signer.signEvent(zapRequestDraft)
+    const separator = callback.includes('?') ? '&' : '?'
     const zapRequestRes = await fetch(
-      `${callback}?amount=${amount}&nostr=${encodeURI(JSON.stringify(zapRequest))}&lnurl=${lnurl}`
+      `${callback}${separator}amount=${amount}&nostr=${encodeURI(JSON.stringify(zapRequest))}&lnurl=${lnurl}`
     )
     const zapRequestResBody = await zapRequestRes.json()
     if (zapRequestResBody.error) {


### PR DESCRIPTION
Fixed bug in lightning.service that prevents zaps to callback urls that contain a "?"

Fix checks for presence of a "?" and concats with "&" instead if it's present