### PR TITLE
fix: add optional pubkey parameter to buildQTag function

### DIFF
--- a/src/lib/draft-event.ts
+++ b/src/lib/draft-event.ts
@@ -784,8 +784,8 @@ function buildPTag(pubkey: string, upperCase: boolean = false) {
   return [upperCase ? 'P' : 'p', pubkey]
 }
 
-function buildQTag(eventHexId: string) {
-  return trimTagEnd(['q', eventHexId, client.getEventHint(eventHexId)]) // TODO: pubkey
+function buildQTag(eventHexId: string, pubkey?: string) {
+  return trimTagEnd(['q', eventHexId, client.getEventHint(eventHexId), pubkey])
 }
 
 function buildReplaceableQTag(coordinate: string) {


### PR DESCRIPTION
## Summary
Resolves the TODO comment in `buildQTag()` by adding an optional `pubkey` parameter to properly implement Nostr NIP-18 quote tag format.

## Changes
- Added `pubkey?: string` parameter to `buildQTag()` function
- Updated return statement to include pubkey in tag array
- Removed TODO comment

## Implementation Details
- Follows the same pattern as `buildETag()` which already has optional pubkey parameter
- Maintains backward compatibility - pubkey is optional, existing calls still work
- Per NIP-18 spec, q tags should follow format: `['q', eventId, relay, pubkey]`

## Testing
- Code compiles without errors
- Existing functionality preserved (optional parameter)
- Callers can now provide pubkey when available for more complete tag information

## Related
Addresses TODO comment at line 787 in `src/lib/draft-event.ts`