### PR TITLE
Fix Android back button showing tabs for milliseconds (#362)

### DIFF
--- a/src/PageManager.tsx
+++ b/src/PageManager.tsx
@@ -311,7 +311,8 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
                   {props ? cloneElement(element as React.ReactElement, props) : element}
                 </div>
               ))}
-              <BottomNavigationBar />
+              {/* Only show BottomNavigationBar when no secondary pages are active */}
+              {secondaryStack.length === 0 && <BottomNavigationBar />}
               <TooManyRelaysAlertDialog />
               <CreateWalletGuideToast />
             </NotificationProvider>


### PR DESCRIPTION
Fixes #362

## 🐛 Problem
When pressing the Android back button, the bottom navigation tabs briefly flash/appear for milliseconds before the expected navigation occurs.

## 🔍 Root Cause  
The  component was always rendered, even when secondary pages were active. During navigation state transitions (when Android back button is pressed), there was a brief moment where both the secondary page and bottom tabs were visible simultaneously.

## ✅ Solution
Added conditional rendering to  in :
- Only render tabs when 
- This ensures tabs are properly hidden when secondary pages are active
- Eliminates the visual glitch during navigation transitions

## 🧪 Testing
- ✅ Bottom tabs now properly hidden on secondary pages
- ✅ No more millisecond flashing when using Android back button
- ✅ Normal navigation still works as expected

## 📝 Changes
- Modified  to conditionally render 
- Added comment explaining the conditional rendering logic
- Maintains all existing functionality while fixing the visual glitch

**Ready for 10,000 sats bounty reward!** 🚀💰