### PR TITLE
feat: display images in TopZaps comments via Content component ligthbox modal

### DIFF
--- a/src/components/StuffStats/TopZaps.tsx
+++ b/src/components/StuffStats/TopZaps.tsx
@@ -2,11 +2,13 @@ import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { useStuffStatsById } from '@/hooks/useStuffStatsById'
 import { useStuff } from '@/hooks/useStuff'
 import { formatAmount } from '@/lib/lightning'
-import { Zap } from 'lucide-react'
+import { Zap, Eye } from 'lucide-react'
 import { Event } from 'nostr-tools'
 import { useMemo, useState } from 'react'
 import { SimpleUserAvatar } from '../UserAvatar'
-import ZapDialog from '../ZapDialog'
+import ZapDetailDialog from '../ZapDetailDialog'
+
+const IMAGE_REGEX = /(https?:\/\/.*\.(?:png|jpg|jpeg|gif|webp))/gi
 
 export default function TopZaps({ stuff }: { stuff: Event | string }) {
   const { event, stuffKey } = useStuff(stuff)
@@ -21,21 +23,25 @@ export default function TopZaps({ stuff }: { stuff: Event | string }) {
   return (
     <ScrollArea className="pb-2 mb-1">
       <div className="flex gap-1">
-        {topZaps.map((zap, index) => (
-          <div
-            key={zap.pr}
-            className="flex gap-1 py-1 pl-1 pr-2 text-sm max-w-72 rounded-full bg-muted/80 items-center text-yellow-400 border border-yellow-400 hover:bg-yellow-400/20 cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation()
-              setZapIndex(index)
-            }}
-          >
-            <SimpleUserAvatar userId={zap.pubkey} size="xSmall" />
-            <Zap className="size-3 fill-yellow-400 shrink-0" />
-            <div className="font-semibold">{formatAmount(zap.amount)}</div>
-            <div className="truncate">{zap.comment}</div>
-            <div onClick={(e) => e.stopPropagation()}>
-              <ZapDialog
+        {topZaps.map((zap, index) => {
+          const hasImage = zap.comment && IMAGE_REGEX.test(zap.comment)
+          const displayText = hasImage ? zap.comment.replace(IMAGE_REGEX, '').trim() : zap.comment
+
+          return (
+            <div
+              key={zap.pr}
+              className="flex gap-1 py-1 pl-1 pr-2 text-sm max-w-72 rounded-full bg-muted/80 items-center text-yellow-400 border border-yellow-400 hover:bg-yellow-400/20 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation()
+                setZapIndex(index)
+              }}
+            >
+              <SimpleUserAvatar userId={zap.pubkey} size="xSmall" />
+              <Zap className="size-3 fill-yellow-400 shrink-0" />
+              <div className="font-semibold">{formatAmount(zap.amount)}</div>
+              {hasImage && <Eye className="size-3 shrink-0" />}
+              {displayText && <div className="truncate">{displayText}</div>}
+              <ZapDetailDialog
                 open={zapIndex === index}
                 setOpen={(open) => {
                   if (open) {
@@ -44,14 +50,11 @@ export default function TopZaps({ stuff }: { stuff: Event | string }) {
                     setZapIndex(-1)
                   }
                 }}
-                pubkey={event.pubkey}
-                event={event}
-                defaultAmount={zap.amount}
-                defaultComment={zap.comment}
+                zap={zap}
               />
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
       <ScrollBar orientation="horizontal" />
     </ScrollArea>

--- a/src/components/StuffStats/TopZaps.tsx
+++ b/src/components/StuffStats/TopZaps.tsx
@@ -25,7 +25,7 @@ export default function TopZaps({ stuff }: { stuff: Event | string }) {
       <div className="flex gap-1">
         {topZaps.map((zap, index) => {
           const hasImage = zap.comment && IMAGE_REGEX.test(zap.comment)
-          const displayText = hasImage ? zap.comment.replace(IMAGE_REGEX, '').trim() : zap.comment
+          const displayText = hasImage ? zap.comment?.replace(IMAGE_REGEX, '').trim() : zap.comment
 
           return (
             <div

--- a/src/components/ZapDetailDialog/index.tsx
+++ b/src/components/ZapDetailDialog/index.tsx
@@ -1,0 +1,84 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle
+} from '@/components/ui/drawer'
+import { formatAmount } from '@/lib/lightning'
+import { Zap } from 'lucide-react'
+import { Dispatch, SetStateAction } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useScreenSize } from '@/providers/ScreenSizeProvider'
+import UserAvatar from '../UserAvatar'
+import Username from '../Username'
+import Content from '../Content'
+import { FormattedTimestamp } from '../FormattedTimestamp'
+
+interface ZapDetailDialogProps {
+  open: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+  zap: {
+    pubkey: string
+    amount: number
+    comment?: string
+    created_at: number
+  }
+}
+
+export default function ZapDetailDialog({ open, setOpen, zap }: ZapDetailDialogProps) {
+  const { t } = useTranslation()
+  const { isSmallScreen } = useScreenSize()
+
+  const content = (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <UserAvatar userId={zap.pubkey} size="medium" />
+        <div className="flex-1">
+          <Username userId={zap.pubkey} className="font-semibold" />
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <FormattedTimestamp timestamp={zap.created_at} />
+          </div>
+        </div>
+        <div className="flex items-center gap-1 text-yellow-400">
+          <Zap className="size-5 fill-yellow-400" />
+          <span className="text-lg font-bold">{formatAmount(zap.amount)}</span>
+        </div>
+      </div>
+      {zap.comment && (
+        <div className="border-t pt-4">
+          <Content content={zap.comment} />
+        </div>
+      )}
+    </div>
+  )
+
+  if (isSmallScreen) {
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent className="px-4 pb-4">
+          <DrawerHeader>
+            <DrawerTitle>{t('Zap Details')}</DrawerTitle>
+          </DrawerHeader>
+          {content}
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>{t('Zap Details')}</DialogTitle>
+        </DialogHeader>
+        {content}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -667,6 +667,7 @@ export default {
       'Warning: Please do not modify these settings casually, as it may affect your basic experience.',
     'Invalid relay URL': 'Invalid relay URL',
     'Muted words': 'Muted words',
-    'Add muted word': 'Add muted word'
+    'Add muted word': 'Add muted word',
+    'Zap Details': 'Zap Details'
   }
 }


### PR DESCRIPTION
This PR enhances the zap display functionality by detecting image URLs in zap comments and providing a better viewing experience as opposed to the redundant zap modal.

The lightbox functionality for images was already part of the existing Content component - this just leverages it by using that component in a new ZapDetailDialog to render zap comments.