### PR TITLE
Use jumble.social share links for notes

### DIFF
--- a/src/components/NoteOptions/useMenuActions.tsx
+++ b/src/components/NoteOptions/useMenuActions.tsx
@@ -1,6 +1,6 @@
 import { formatError } from '@/lib/error'
 import { getNoteBech32Id, isProtectedEvent } from '@/lib/event'
-import { toNjump } from '@/lib/link'
+import { toJumbleNote } from '@/lib/link'
 import { pubkeyToNpub } from '@/lib/pubkey'
 import { simplifyUrl } from '@/lib/url'
 import { useCurrentRelays } from '@/providers/CurrentRelaysProvider'
@@ -183,7 +183,7 @@ export function useMenuActions({
         icon: Link,
         label: t('Copy share link'),
         onClick: () => {
-          navigator.clipboard.writeText(toNjump(getNoteBech32Id(event)))
+          navigator.clipboard.writeText(toJumbleNote(event))
           closeDrawer()
         }
       },

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -8,6 +8,9 @@ export const toNote = (eventOrId: Event | string) => {
   const nevent = getNoteBech32Id(eventOrId)
   return `/notes/${nevent}`
 }
+export const toJumbleNote = (eventOrId: Event | string) => {
+  return `https://jumble.social${toNote(eventOrId)}`
+}
 export const toNoteList = ({
   hashtag,
   search,
@@ -86,7 +89,6 @@ export const toFollowPack = (eventOrId: Event | string) => {
 export const toChachiChat = (relay: string, d: string) => {
   return `https://chachi.chat/${relay.replace(/^wss?:\/\//, '').replace(/\/$/, '')}/${d}`
 }
-export const toNjump = (id: string) => `https://njump.me/${id}`
 export const toUserAggregationDetail = (feedId: string, pubkey: string) => {
   const npub = nip19.npubEncode(pubkey)
   return `/user-aggregation/${feedId}/${npub}`


### PR DESCRIPTION
  - Replace njump.me share links with jumble.social note URLs in the note options menu.
  - Add a dedicated helper for absolute jumble.social note links.