### PR TITLE
feat: toggle to hide followed users in relay set feeds

### DIFF
--- a/src/components/NormalFeed/index.tsx
+++ b/src/components/NormalFeed/index.tsx
@@ -7,7 +7,8 @@ import { useKindFilter } from '@/providers/KindFilterProvider'
 import { useUserTrust } from '@/providers/UserTrustProvider'
 import storage from '@/services/local-storage.service'
 import { TFeedSubRequest, TNoteListMode } from '@/types'
-import { useMemo, useRef, useState } from 'react'
+import { Event } from 'nostr-tools'
+import { ReactNode, useMemo, useRef, useState } from 'react'
 import KindFilter from '../KindFilter'
 import { RefreshButton } from '../RefreshButton'
 
@@ -19,7 +20,9 @@ export default function NormalFeed({
   showRelayCloseReason = false,
   disable24hMode = false,
   onRefresh,
-  isPubkeyFeed = false
+  isPubkeyFeed = false,
+  noteFilterFn,
+  extraOptions
 }: {
   trustScoreFilterId?: string
   subRequests: TFeedSubRequest[]
@@ -29,6 +32,8 @@ export default function NormalFeed({
   disable24hMode?: boolean
   onRefresh?: () => void
   isPubkeyFeed?: boolean
+  noteFilterFn?: (event: Event) => boolean
+  extraOptions?: ReactNode
 }) {
   const { showKinds } = useKindFilter()
   const { getMinTrustScore } = useUserTrust()
@@ -104,6 +109,7 @@ export default function NormalFeed({
                 onShowKindsChange={handleShowKindsChange}
               />
             )}
+            {extraOptions}
           </>
         }
         active={trustFilterOpen}
@@ -118,6 +124,7 @@ export default function NormalFeed({
           showRelayCloseReason={showRelayCloseReason}
           isPubkeyFeed={isPubkeyFeed}
           trustScoreThreshold={trustScoreThreshold}
+          filterFn={noteFilterFn}
         />
       ) : (
         <NoteList
@@ -129,6 +136,7 @@ export default function NormalFeed({
           showRelayCloseReason={showRelayCloseReason}
           isPubkeyFeed={isPubkeyFeed}
           trustScoreThreshold={trustScoreThreshold}
+          filterFn={noteFilterFn}
         />
       )}
     </>

--- a/src/components/UserAggregationList/index.tsx
+++ b/src/components/UserAggregationList/index.tsx
@@ -56,6 +56,7 @@ const UserAggregationList = forwardRef<
     showRelayCloseReason?: boolean
     isPubkeyFeed?: boolean
     trustScoreThreshold?: number
+    filterFn?: (event: Event) => boolean
   }
 >(
   (
@@ -66,7 +67,8 @@ const UserAggregationList = forwardRef<
       areAlgoRelays = false,
       showRelayCloseReason = false,
       isPubkeyFeed = false,
-      trustScoreThreshold
+      trustScoreThreshold,
+      filterFn
     },
     ref
   ) => {
@@ -284,6 +286,7 @@ const UserAggregationList = forwardRef<
             ) {
               return null
             }
+            if (filterFn && !filterFn(evt)) return null
             if (
               trustScoreThreshold &&
               !(await meetsMinTrustScore(evt.pubkey, trustScoreThreshold))
@@ -305,6 +308,7 @@ const UserAggregationList = forwardRef<
         filterMutedNotes,
         hideContentMentioningMutedUsers,
         isMentioningMutedUsers,
+        filterFn,
         meetsMinTrustScore,
         trustScoreThreshold
       ]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const StorageKey = {
   ADD_CLIENT_TAG: 'addClientTag',
   NOTE_LIST_MODE: 'noteListMode',
   NOTIFICATION_TYPE: 'notificationType',
+  HIDE_FOLLOWING_IN_RELAY_SET_MAP: 'hideFollowingInRelaySetMap',
   DEFAULT_ZAP_SATS: 'defaultZapSats',
   DEFAULT_ZAP_COMMENT: 'defaultZapComment',
   QUICK_ZAP: 'quickZap',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export default {
     Profile: 'Profile',
     Logout: 'Logout',
     Following: 'Following',
+    'Hide people you follow': 'Hide people you follow',
     followings: 'followings',
     reposted: 'reposted',
     'just now': 'just now',

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -12,6 +12,7 @@ export default {
     Profile: 'Perfil',
     Logout: 'Sair',
     Following: 'Seguindo',
+    'Hide people you follow': 'Ocultar pessoas que você segue',
     followings: 'Seguidos',
     reposted: 'Repostado',
     'just now': 'agora mesmo',

--- a/src/pages/primary/NoteListPage/RelaysFeed.tsx
+++ b/src/pages/primary/NoteListPage/RelaysFeed.tsx
@@ -1,13 +1,27 @@
 import NormalFeed from '@/components/NormalFeed'
+import { Button } from '@/components/ui/button'
 import { checkAlgoRelay } from '@/lib/relay'
 import { useFeed } from '@/providers/FeedProvider'
+import { useFollowList } from '@/providers/FollowListProvider'
+import { useNostr } from '@/providers/NostrProvider'
 import relayInfoService from '@/services/relay-info.service'
+import storage from '@/services/local-storage.service'
+import { Event } from 'nostr-tools'
+import { UserMinus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export default function RelaysFeed() {
+  const { t } = useTranslation()
   const { relayUrls, feedInfo } = useFeed()
+  const { pubkey } = useNostr()
+  const { followingSet } = useFollowList()
   const [isReady, setIsReady] = useState(false)
   const [areAlgoRelays, setAreAlgoRelays] = useState(false)
+  const relaySetId = useMemo(() => {
+    return feedInfo?.feedType === 'relays' && feedInfo.id ? feedInfo.id : null
+  }, [feedInfo])
+  const [hideFollowing, setHideFollowing] = useState(false)
   const trustScoreFilterId = useMemo(() => {
     if (feedInfo?.feedType === 'relay' && feedInfo.id) {
       return `relay-${feedInfo.id}`
@@ -18,6 +32,14 @@ export default function RelaysFeed() {
   }, [feedInfo])
 
   useEffect(() => {
+    if (!relaySetId) {
+      setHideFollowing(false)
+      return
+    }
+    setHideFollowing(storage.getHideFollowingInRelaySet(relaySetId))
+  }, [relaySetId])
+
+  useEffect(() => {
     const init = async () => {
       const relayInfos = await relayInfoService.getRelayInfos(relayUrls)
       setAreAlgoRelays(relayInfos.every((relayInfo) => checkAlgoRelay(relayInfo)))
@@ -25,6 +47,12 @@ export default function RelaysFeed() {
     }
     init()
   }, [relayUrls])
+
+  const canHideFollowing = !!pubkey && !!relaySetId && followingSet.size > 0
+  const noteFilterFn = useMemo(() => {
+    if (!canHideFollowing || !hideFollowing) return undefined
+    return (evt: Event) => !followingSet.has(evt.pubkey)
+  }, [canHideFollowing, hideFollowing, followingSet])
 
   if (!isReady) {
     return null
@@ -37,6 +65,31 @@ export default function RelaysFeed() {
       areAlgoRelays={areAlgoRelays}
       isMainFeed
       showRelayCloseReason
+      noteFilterFn={noteFilterFn}
+      extraOptions={
+        canHideFollowing ? (
+          <Button
+            variant="ghost"
+            size="titlebar-icon"
+            className={
+              hideFollowing
+                ? 'text-primary hover:text-primary-hover'
+                : 'text-muted-foreground hover:text-foreground'
+            }
+            title={t('Hide people you follow')}
+            aria-label={t('Hide people you follow')}
+            onClick={() => {
+              const next = !hideFollowing
+              setHideFollowing(next)
+              if (relaySetId) {
+                storage.setHideFollowingInRelaySet(relaySetId, next)
+              }
+            }}
+          >
+            <UserMinus size={16} />
+          </Button>
+        ) : null
+      }
     />
   )
 }

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -68,6 +68,7 @@ class LocalStorageService {
   private mutedWords: string[] = []
   private minTrustScore: number = 0
   private minTrustScoreMap: Record<string, number> = {}
+  private hideFollowingInRelaySetMap: Record<string, boolean> = {}
   private hideIndirectNotifications: boolean = false
 
   constructor() {
@@ -286,6 +287,20 @@ class LocalStorageService {
         const map = JSON.parse(minTrustScoreMapStr)
         if (typeof map === 'object' && map !== null) {
           this.minTrustScoreMap = map
+        }
+      } catch {
+        // Invalid JSON, use default
+      }
+    }
+
+    const hideFollowingInRelaySetMapStr = window.localStorage.getItem(
+      StorageKey.HIDE_FOLLOWING_IN_RELAY_SET_MAP
+    )
+    if (hideFollowingInRelaySetMapStr) {
+      try {
+        const map = JSON.parse(hideFollowingInRelaySetMapStr)
+        if (typeof map === 'object' && map !== null) {
+          this.hideFollowingInRelaySetMap = map
         }
       } catch {
         // Invalid JSON, use default
@@ -669,6 +684,18 @@ class LocalStorageService {
   setMinTrustScoreMap(map: Record<string, number>) {
     this.minTrustScoreMap = map
     window.localStorage.setItem(StorageKey.MIN_TRUST_SCORE_MAP, JSON.stringify(map))
+  }
+
+  getHideFollowingInRelaySet(relaySetId: string) {
+    return this.hideFollowingInRelaySetMap[relaySetId] === true
+  }
+
+  setHideFollowingInRelaySet(relaySetId: string, hide: boolean) {
+    this.hideFollowingInRelaySetMap[relaySetId] = hide
+    window.localStorage.setItem(
+      StorageKey.HIDE_FOLLOWING_IN_RELAY_SET_MAP,
+      JSON.stringify(this.hideFollowingInRelaySetMap)
+    )
   }
 
   getDefaultRelayUrls() {


### PR DESCRIPTION
Fixes #157.\n\nAdds a per-relay-set toggle (icon button in the feed controls) to hide notes from pubkeys you already follow when browsing a relay set feed (feedType=relays). The preference is stored per relay set id in localStorage.\n\nBuild/lint verified locally (Feb 10, 2026):\n- npm ci\n- npm run build\n- npm run lint\n\nBounty: https://app.lightningbounties.com/issue/dc34224d-d9d5-4f57-bdc4-bb5c5fed63da\n\nMax (SATMAX Agent)