### PR TITLE
feat: mention/autocomplete NIP-51 follow-set lists (kind 30000)

### DIFF
--- a/src/components/ContentPreview/Nip51ListPreview.tsx
+++ b/src/components/ContentPreview/Nip51ListPreview.tsx
@@ -1,0 +1,25 @@
+import { getNip51FollowSetInfoFromEvent } from '@/lib/event-metadata'
+import { cn } from '@/lib/utils'
+import { Event } from 'nostr-tools'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export default function Nip51ListPreview({ event, className }: { event: Event; className?: string }) {
+  const { t } = useTranslation()
+  const { title, description, pubkeys } = useMemo(() => getNip51FollowSetInfoFromEvent(event), [event])
+
+  return (
+    <div className={cn('rounded-lg border bg-muted/30 p-3', className)}>
+      <div className="flex items-center gap-2">
+        <div className="truncate text-base font-semibold">{title}</div>
+        <div className="shrink-0 text-xs text-muted-foreground">{t('n users', { count: pubkeys.length })}</div>
+      </div>
+      {description ? (
+        <div className="mt-1 line-clamp-3 whitespace-pre-wrap text-sm text-muted-foreground">
+          {description}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+

--- a/src/components/ContentPreview/index.tsx
+++ b/src/components/ContentPreview/index.tsx
@@ -1,4 +1,4 @@
-import { ExtendedKind } from '@/constants'
+import { ExtendedKind, NIP51_LIST_KIND_FOLLOW_SET } from '@/constants'
 import { isMentioningMutedUsers } from '@/lib/event'
 import { cn } from '@/lib/utils'
 import { useContentPolicy } from '@/providers/ContentPolicyProvider'
@@ -14,6 +14,7 @@ import HighlightPreview from './HighlightPreview'
 import LiveEventPreview from './LiveEventPreview'
 import LongFormArticlePreview from './LongFormArticlePreview'
 import NormalContentPreview from './NormalContentPreview'
+import Nip51ListPreview from './Nip51ListPreview'
 import PictureNotePreview from './PictureNotePreview'
 import PollPreview from './PollPreview'
 import VideoNotePreview from './VideoNotePreview'
@@ -108,6 +109,10 @@ export default function ContentPreview({
 
   if (event.kind === ExtendedKind.FOLLOW_PACK) {
     return <FollowPackPreview event={event} className={className} />
+  }
+
+  if (event.kind === NIP51_LIST_KIND_FOLLOW_SET) {
+    return <Nip51ListPreview event={event} className={className} />
   }
 
   return <div className={className}>[{t('Cannot handle event of kind k', { k: event.kind })}]</div>

--- a/src/components/PostEditor/PostTextarea/Mention/MentionList.tsx
+++ b/src/components/PostEditor/PostTextarea/Mention/MentionList.tsx
@@ -1,15 +1,18 @@
 import FollowingBadge from '@/components/FollowingBadge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { formatNpub, userIdToPubkey } from '@/lib/pubkey'
 import { cn } from '@/lib/utils'
 import { SuggestionKeyDownProps } from '@tiptap/suggestion'
+import { List } from 'lucide-react'
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 import Nip05 from '../../../Nip05'
 import { SimpleUserAvatar } from '../../../UserAvatar'
 import { SimpleUsername } from '../../../Username'
+import { TMentionTarget } from './types'
 
 export interface MentionListProps {
-  items: string[]
+  items: TMentionTarget[]
   command: (payload: { id: string; label?: string }) => void
 }
 
@@ -18,22 +21,34 @@ export interface MentionListHandle {
 }
 
 const MentionList = forwardRef<MentionListHandle, MentionListProps>((props, ref) => {
+  const profileItems = props.items.filter((i) => i.type === 'profile')
+  const listItems = props.items.filter((i) => i.type === 'list')
+  const showTabs = profileItems.length > 0 && listItems.length > 0
+
+  const [tab, setTab] = useState<'profiles' | 'lists'>(profileItems.length > 0 ? 'profiles' : 'lists')
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
 
-  const selectItem = (index: number) => {
-    const item = props.items[index]
+  const activeItems = tab === 'profiles' ? profileItems : listItems
 
-    if (item) {
-      props.command({ id: item, label: formatNpub(item) })
+  const selectItem = (index: number) => {
+    const item = activeItems[index]
+    if (!item) return
+
+    if (item.type === 'profile') {
+      props.command({ id: item.id, label: formatNpub(item.id) })
+    } else {
+      props.command({ id: item.id, label: item.title })
     }
   }
 
   const upHandler = () => {
-    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length)
+    if (!activeItems.length) return
+    setSelectedIndex((selectedIndex + activeItems.length - 1) % activeItems.length)
   }
 
   const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length)
+    if (!activeItems.length) return
+    setSelectedIndex((selectedIndex + 1) % activeItems.length)
   }
 
   const enterHandler = () => {
@@ -41,8 +56,19 @@ const MentionList = forwardRef<MentionListHandle, MentionListProps>((props, ref)
   }
 
   useEffect(() => {
-    setSelectedIndex(props.items.length ? 0 : -1)
-  }, [props.items])
+    // Prefer keeping the active tab when possible, but auto-switch if it becomes empty.
+    let nextTab = tab
+    if (nextTab === 'profiles' && profileItems.length === 0 && listItems.length > 0) {
+      nextTab = 'lists'
+    } else if (nextTab === 'lists' && listItems.length === 0 && profileItems.length > 0) {
+      nextTab = 'profiles'
+    }
+    if (nextTab !== tab) {
+      setTab(nextTab)
+    }
+    const nextActiveItems = nextTab === 'profiles' ? profileItems : listItems
+    setSelectedIndex(nextActiveItems.length ? 0 : -1)
+  }, [props.items, tab])
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }: SuggestionKeyDownProps) => {
@@ -75,28 +101,70 @@ const MentionList = forwardRef<MentionListHandle, MentionListProps>((props, ref)
       onWheel={(e) => e.stopPropagation()}
       onTouchMove={(e) => e.stopPropagation()}
     >
-      {props.items.map((item, index) => (
-        <button
-          className={cn(
-            'm-1 cursor-pointer items-center rounded-md p-2 text-start outline-none transition-colors [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-            selectedIndex === index && 'bg-accent text-accent-foreground'
-          )}
-          key={item}
-          onClick={() => selectItem(index)}
-          onMouseEnter={() => setSelectedIndex(index)}
-        >
-          <div className="pointer-events-none flex w-80 items-center gap-2 truncate">
-            <SimpleUserAvatar userId={item} />
-            <div className="w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <SimpleUsername userId={item} className="truncate font-semibold" />
-                <FollowingBadge userId={item} />
+      {showTabs ? (
+        <div className="sticky top-0 z-10 border-b bg-background/90 p-2 backdrop-blur">
+          <Tabs value={tab} onValueChange={(v) => setTab(v as 'profiles' | 'lists')}>
+            <TabsList className="w-full">
+              <TabsTrigger value="profiles" className="flex-1">
+                Profiles
+              </TabsTrigger>
+              <TabsTrigger value="lists" className="flex-1">
+                Lists
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      ) : null}
+
+      {activeItems.map((item, index) => {
+        const selected = selectedIndex === index
+        if (item.type === 'profile') {
+          return (
+            <button
+              className={cn(
+                'm-1 cursor-pointer items-center rounded-md p-2 text-start outline-none transition-colors [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+                selected && 'bg-accent text-accent-foreground'
+              )}
+              key={`profile:${item.id}`}
+              onClick={() => selectItem(index)}
+              onMouseEnter={() => setSelectedIndex(index)}
+            >
+              <div className="pointer-events-none flex w-80 items-center gap-2 truncate">
+                <SimpleUserAvatar userId={item.id} />
+                <div className="w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <SimpleUsername userId={item.id} className="truncate font-semibold" />
+                    <FollowingBadge userId={item.id} />
+                  </div>
+                  <Nip05 pubkey={userIdToPubkey(item.id)} />
+                </div>
               </div>
-              <Nip05 pubkey={userIdToPubkey(item)} />
+            </button>
+          )
+        }
+
+        return (
+          <button
+            className={cn(
+              'm-1 cursor-pointer items-center rounded-md p-2 text-start outline-none transition-colors [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+              selected && 'bg-accent text-accent-foreground'
+            )}
+            key={`list:${item.id}`}
+            onClick={() => selectItem(index)}
+            onMouseEnter={() => setSelectedIndex(index)}
+          >
+            <div className="pointer-events-none flex w-80 items-center gap-2 truncate">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-full border bg-muted/50">
+                <List className="size-4" />
+              </div>
+              <div className="w-0 flex-1">
+                <div className="truncate font-semibold">{item.title}</div>
+                <div className="text-xs text-muted-foreground">{`${item.count} users`}</div>
+              </div>
             </div>
-          </div>
-        </button>
-      ))}
+          </button>
+        )
+      })}
     </ScrollArea>
   )
 })

--- a/src/components/PostEditor/PostTextarea/Mention/MentionNode.tsx
+++ b/src/components/PostEditor/PostTextarea/Mention/MentionNode.tsx
@@ -1,22 +1,60 @@
 import TextWithEmojis from '@/components/TextWithEmojis'
-import { useFetchProfile } from '@/hooks'
+import { getNip51FollowSetInfoFromEvent } from '@/lib/event-metadata'
 import { formatUserId } from '@/lib/pubkey'
 import { cn } from '@/lib/utils'
+import client from '@/services/client.service'
+import { TEmoji } from '@/types'
 import { NodeViewRendererProps, NodeViewWrapper } from '@tiptap/react'
+import { useEffect, useState } from 'react'
 
 export default function MentionNode(props: NodeViewRendererProps & { selected: boolean }) {
-  const { profile } = useFetchProfile(props.node.attrs.id)
+  const id = props.node.attrs.id as string
+  const fallbackLabel = (props.node.attrs.label as string | undefined) ?? formatUserId(id)
+
+  const [label, setLabel] = useState<string>(fallbackLabel)
+  const [emojis, setEmojis] = useState<TEmoji[]>([])
+  const isList = typeof id === 'string' && id.startsWith('naddr')
+
+  useEffect(() => {
+    let cancelled = false
+    setLabel(fallbackLabel)
+    setEmojis([])
+
+    const run = async () => {
+      if (!id) return
+      try {
+        if (isList) {
+          const event = await client.fetchEvent(id)
+          if (!event) return
+          const info = getNip51FollowSetInfoFromEvent(event)
+          if (!cancelled) {
+            setLabel(info.title)
+          }
+          return
+        }
+
+        const profile = await client.fetchProfile(id)
+        if (profile && !cancelled) {
+          setLabel(profile.username)
+          setEmojis(profile.emojis ?? [])
+        }
+      } catch {
+        // ignore and keep fallback
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [id, fallbackLabel, isList])
 
   return (
     <NodeViewWrapper
       className={cn('inline text-primary', props.selected ? 'rounded-sm bg-primary/20' : '')}
     >
       {'@'}
-      {profile ? (
-        <TextWithEmojis text={profile.username} emojis={profile.emojis} emojiClassName="mb-1" />
-      ) : (
-        formatUserId(props.node.attrs.id)
-      )}
+      <TextWithEmojis text={label} emojis={emojis} emojiClassName="mb-1" />
     </NodeViewWrapper>
   )
 }

--- a/src/components/PostEditor/PostTextarea/Mention/suggestion.ts
+++ b/src/components/PostEditor/PostTextarea/Mention/suggestion.ts
@@ -5,10 +5,19 @@ import { ReactRenderer } from '@tiptap/react'
 import { SuggestionKeyDownProps } from '@tiptap/suggestion'
 import tippy, { GetReferenceClientRect, Instance, Props } from 'tippy.js'
 import MentionList, { MentionListHandle, MentionListProps } from './MentionList'
+import { TMentionTarget } from './types'
 
 const suggestion = {
-  items: async ({ query }: { query: string }) => {
-    return await client.searchNpubsFromLocal(query, 20)
+  items: async ({ query }: { query: string }): Promise<TMentionTarget[]> => {
+    const [profiles, lists] = await Promise.all([
+      client.searchNpubsFromLocal(query, 20),
+      client.searchNip51FollowSetMentionsFromLocal(query, 20)
+    ])
+
+    return [
+      ...profiles.map((id) => ({ type: 'profile' as const, id })),
+      ...lists.map((l) => ({ type: 'list' as const, id: l.id, title: l.title, count: l.count }))
+    ]
   },
 
   render: () => {

--- a/src/components/PostEditor/PostTextarea/Mention/types.ts
+++ b/src/components/PostEditor/PostTextarea/Mention/types.ts
@@ -1,0 +1,4 @@
+export type TMentionTarget =
+  | { type: 'profile'; id: string }
+  | { type: 'list'; id: string; title: string; count: number }
+

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,6 +85,10 @@ export const TRENDING_NOTES_RELAY_URLS = ['wss://trending.relays.land/']
 
 export const GROUP_METADATA_EVENT_KIND = 39000
 
+// NIP-51 Lists: https://github.com/nostr-protocol/nips/blob/master/51.md
+// Coracle “Nostr list” uses kind 30000 for follow sets.
+export const NIP51_LIST_KIND_FOLLOW_SET = 30000
+
 export const ExtendedKind = {
   EXTERNAL_CONTENT_REACTION: 17,
   PICTURE: 20,

--- a/src/lib/event-metadata.ts
+++ b/src/lib/event-metadata.ts
@@ -431,3 +431,28 @@ export function getFollowPackInfoFromEvent(event: Event) {
 
   return { title, description, image, pubkeys }
 }
+
+// NIP-51 follow set list (kind 30000).
+// Coracle uses kind 30000 with p-tags for members and metadata in tags (title/name/description).
+export function getNip51FollowSetInfoFromEvent(event: Event) {
+  let title: string | undefined
+  let description: string | undefined
+  const pubkeys: string[] = []
+
+  event.tags.forEach(([tagName, tagValue]) => {
+    if (!tagValue) return
+    if (tagName === 'title' || tagName === 'name') {
+      title = tagValue
+    } else if (tagName === 'description') {
+      description = tagValue
+    } else if (tagName === 'p' && isValidPubkey(tagValue)) {
+      pubkeys.push(tagValue)
+    }
+  })
+
+  if (!title) {
+    title = event.tags.find(tagNameEquals('d'))?.[1] ?? 'Untitled List'
+  }
+
+  return { title, description, pubkeys }
+}


### PR DESCRIPTION
Closes #283.

What this adds
- IndexedDB support for NIP-51 follow set events (kind 30000) so embedded `naddr...` lists can be fetched and cached.
- Content preview for kind 30000 follow sets (shows title + user count + optional description).
- Mention autocomplete tabs: Profiles vs Lists (lists are sourced from locally-cached kind 30000 events).
- Editor mention rendering supports list mentions (renders as `@<list title>`).

Notes
- Lists will show up in the mention autocomplete after Jumble has seen/cached the list event (for example via an embedded `nostr:naddr...` in a note).

Local verification (2026-02-11)
- `npm run lint`
- `npm run build`

LightningBounties
- https://app.lightningbounties.com/issue/950c01ab-361a-4864-a698-a3ab8f32a21c
