### PR TITLE
fix: preserve line breaks in longform article summaries

### DIFF
--- a/src/components/Note/LongFormArticle/index.tsx
+++ b/src/components/Note/LongFormArticle/index.tsx
@@ -96,7 +96,7 @@ export default function LongFormArticle({
         <h1 className="break-words">{metadata.title}</h1>
         {metadata.summary && (
           <blockquote>
-            <p className="break-words">{metadata.summary}</p>
+            <p className="whitespace-pre-line break-words">{metadata.summary}</p>
           </blockquote>
         )}
         {metadata.image && (

--- a/src/components/Note/LongFormArticlePreview.tsx
+++ b/src/components/Note/LongFormArticlePreview.tsx
@@ -39,7 +39,7 @@ export default function LongFormArticlePreview({
   )
 
   const summaryComponent = metadata.summary && (
-    <div className="line-clamp-4 text-sm text-muted-foreground">{metadata.summary}</div>
+    <div className="line-clamp-4 whitespace-pre-line text-sm text-muted-foreground">{metadata.summary}</div>
   )
 
   if (isSmallScreen) {


### PR DESCRIPTION
## Summary
Add `whitespace-pre-line` to longform article summary elements so that newline characters in the `summary` tag are rendered as visible line breaks instead of being collapsed.

Updated both the full article view (`LongFormArticle`) and the feed preview card (`LongFormArticlePreview`).

### Screenshots
before
<img width="642" height="743" alt="before" src="https://github.com/user-attachments/assets/0039ef39-1b4e-423c-8ccc-9f0bf564b443" />

after
<img width="642" height="743" alt="after" src="https://github.com/user-attachments/assets/fe10424e-e66e-48c5-8d79-e16fa07390b1" />