### PR TITLE
fix: render raw npub/nprofile strings as inline mentions

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -3,6 +3,7 @@ import {
   EmbeddedEmojiParser,
   EmbeddedEventParser,
   EmbeddedHashtagParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedLNInvoiceParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
@@ -69,6 +70,7 @@ export default function Content({
     const nodes = parseContent(_content, [
       EmbeddedEventParser,
       EmbeddedMentionParser,
+      EmbeddedLegacyMentionParser,
       EmbeddedUrlParser,
       EmbeddedLNInvoiceParser,
       EmbeddedWebsocketUrlParser,
@@ -251,6 +253,9 @@ export default function Content({
           }
           if (node.type === 'mention') {
             return <EmbeddedMention key={index} userId={node.data.split(':')[1]} />
+          }
+          if (node.type === 'legacy-mention') {
+            return <EmbeddedMention key={index} userId={node.data} />
           }
           if (node.type === 'hashtag') {
             return <EmbeddedHashtag hashtag={node.data} key={index} />

--- a/src/components/ContentPreview/Content.tsx
+++ b/src/components/ContentPreview/Content.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedEmojiParser,
   EmbeddedEventParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
   parseContent
@@ -26,6 +27,7 @@ export default function Content({
     return parseContent(content, [
       EmbeddedEventParser,
       EmbeddedMentionParser,
+      EmbeddedLegacyMentionParser,
       EmbeddedUrlParser,
       EmbeddedEmojiParser
     ])
@@ -45,6 +47,9 @@ export default function Content({
         }
         if (node.type === 'mention') {
           return <EmbeddedMentionText key={index} userId={node.data.split(':')[1]} />
+        }
+        if (node.type === 'legacy-mention') {
+          return <EmbeddedMentionText key={index} userId={node.data} />
         }
         if (node.type === 'emoji') {
           const shortcode = node.data.split(':')[1]

--- a/src/components/ProfileAbout/index.tsx
+++ b/src/components/ProfileAbout/index.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedEmojiParser,
   EmbeddedHashtagParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
   EmbeddedWebsocketUrlParser,
@@ -40,6 +41,7 @@ export default function ProfileAbout({
 
     const nodes = parseContent(translatedAbout ?? about, [
       EmbeddedMentionParser,
+      EmbeddedLegacyMentionParser,
       EmbeddedWebsocketUrlParser,
       EmbeddedUrlParser,
       EmbeddedHashtagParser,
@@ -64,6 +66,9 @@ export default function ProfileAbout({
       }
       if (node.type === 'mention') {
         return <EmbeddedMention key={index} userId={node.data.split(':')[1]} />
+      }
+      if (node.type === 'legacy-mention') {
+        return <EmbeddedMention key={index} userId={node.data} />
       }
       if (node.type === 'emoji') {
         const shortcode = node.data.split(':')[1]


### PR DESCRIPTION
## Summary
- Wires up the existing `EmbeddedLegacyMentionParser` (which matches bare `npub1…` / `nprofile1…` without a `nostr:` prefix) in all three content renderers so they display as clickable user mentions
- Parser ordering ensures `nostr:`-prefixed mentions are captured first; only unprefixed strings remaining in text nodes are matched by the legacy parser

## Context
Some Nostr clients paste raw npub/nprofile identifiers into note content without the standard `nostr:` prefix. These currently render as plain text. The `EmbeddedLegacyMentionParser` already existed in `content-parser.ts` but was never imported or used by any renderer.

## Changes
- **`Content/index.tsx`** — added parser + render case for `'legacy-mention'`
- **`ContentPreview/Content.tsx`** — added parser + render case for `'legacy-mention'`
- **`ProfileAbout/index.tsx`** — added parser + render case for `'legacy-mention'`

## Screenshots
Before:
<img width="1278" height="402" alt="image" src="https://github.com/user-attachments/assets/320c9282-37f3-466c-a4fd-2e373b41e703" />

After:
<img width="1274" height="356" alt="image" src="https://github.com/user-attachments/assets/3838d8e1-0c5f-4111-a527-7b44b4ffdca4" />

## Test plan
- [ ] Verify a note containing a bare `npub1…` renders as a clickable @mention with profile hover card
- [ ] Verify a note containing a bare `nprofile1…` renders the same way
- [ ] Verify `nostr:npub1…` still renders correctly (not double-matched)
- [ ] Verify content previews and profile about sections also render legacy mentions