### PR TITLE
feat: Namecoin NIP-05 identity resolution (.bit domains)

### DIFF
--- a/src/components/Nip05/index.tsx
+++ b/src/components/Nip05/index.tsx
@@ -3,12 +3,12 @@ import { useFetchProfile } from '@/hooks'
 import { useFetchNip05 } from '@/hooks/useFetchNip05'
 import { toNoteList } from '@/lib/link'
 import { SecondaryPageLink } from '@/PageManager'
-import { BadgeAlert, BadgeCheck } from 'lucide-react'
+import { BadgeAlert, BadgeCheck, ShieldCheck } from 'lucide-react'
 import { Favicon } from '../Favicon'
 
 export default function Nip05({ pubkey, append }: { pubkey: string; append?: string }) {
   const { profile } = useFetchProfile(pubkey)
-  const { nip05IsVerified, nip05Name, nip05Domain, isFetching } = useFetchNip05(
+  const { nip05IsVerified, nip05Name, nip05Domain, isNamecoin, isFetching } = useFetchNip05(
     profile?.nip05,
     pubkey
   )
@@ -32,11 +32,15 @@ export default function Nip05({ pubkey, append }: { pubkey: string; append?: str
         <span className="truncate text-sm text-muted-foreground">@{nip05Name}</span>
       ) : null}
       {nip05IsVerified ? (
-        <Favicon
-          domain={nip05Domain}
-          className="h-3.5 w-3.5 shrink-0 rounded-full"
-          fallback={<BadgeCheck className="shrink-0 text-primary" />}
-        />
+        isNamecoin ? (
+          <ShieldCheck className="shrink-0 text-teal-500" />
+        ) : (
+          <Favicon
+            domain={nip05Domain}
+            className="h-3.5 w-3.5 shrink-0 rounded-full"
+            fallback={<BadgeCheck className="shrink-0 text-primary" />}
+          />
+        )
       ) : (
         <BadgeAlert className="shrink-0 text-muted-foreground" />
       )}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,6 +1,7 @@
 import SearchInput from '@/components/SearchInput'
 import { useSearchProfiles } from '@/hooks'
 import { toExternalContent, toNote } from '@/lib/link'
+import { isNamecoinIdentifier, resolveNamecoin } from '@/lib/namecoin'
 import { formatFeedRequest, parseNakReqCommand } from '@/lib/nak-parser'
 import { randomString } from '@/lib/random'
 import { normalizeUrl } from '@/lib/url'
@@ -9,7 +10,7 @@ import { useSecondaryPage } from '@/PageManager'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import modalManager from '@/services/modal-manager.service'
 import { TSearchParams } from '@/types'
-import { Hash, MessageSquare, Notebook, Search, Server, Terminal } from 'lucide-react'
+import { Hash, MessageSquare, Notebook, Search, Server, ShieldCheck, Terminal } from 'lucide-react'
 import { nip19 } from 'nostr-tools'
 import {
   forwardRef,
@@ -43,10 +44,30 @@ const SearchBar = forwardRef<
     const id = search.startsWith('nostr:') ? search.slice(6) : search
     return /^(npub1|nprofile1|note1|nevent1|naddr1)/.test(id)
   }, [debouncedInput])
+  const isNmcSearch = useMemo(() => isNamecoinIdentifier(debouncedInput.trim()), [debouncedInput])
+  const [nmcResolvedPubkey, setNmcResolvedPubkey] = useState<string | null>(null)
+  const [isResolvingNmc, setIsResolvingNmc] = useState(false)
   const { profiles, isFetching: isFetchingProfiles } = useSearchProfiles(
-    isIdSearch ? '' : debouncedInput,
+    isIdSearch || isNmcSearch ? '' : debouncedInput,
     5
   )
+
+  // Resolve Namecoin identifiers
+  useEffect(() => {
+    if (!isNmcSearch) {
+      setNmcResolvedPubkey(null)
+      setIsResolvingNmc(false)
+      return
+    }
+    setIsResolvingNmc(true)
+    resolveNamecoin(debouncedInput.trim()).then((result) => {
+      setNmcResolvedPubkey(result?.pubkey ?? null)
+      setIsResolvingNmc(false)
+    }).catch(() => {
+      setNmcResolvedPubkey(null)
+      setIsResolvingNmc(false)
+    })
+  }, [debouncedInput, isNmcSearch])
   const [searching, setSearching] = useState(false)
   const [displayList, setDisplayList] = useState(false)
   const [selectableOptions, setSelectableOptions] = useState<TSearchParams[]>([])
@@ -154,6 +175,22 @@ const SearchBar = forwardRef<
       // ignore
     }
 
+    // Namecoin identifier resolved to a pubkey
+    if (isNmcSearch && nmcResolvedPubkey) {
+      const npub = nip19.npubEncode(nmcResolvedPubkey)
+      setSelectableOptions([{ type: 'profile', search: npub, input: search }])
+      return
+    }
+    if (isNmcSearch && isResolvingNmc) {
+      setSelectableOptions([])
+      return
+    }
+    if (isNmcSearch && !nmcResolvedPubkey) {
+      // Namecoin name not found, show as text search
+      setSelectableOptions([{ type: 'notes', search }])
+      return
+    }
+
     const hashtag = search.match(/[\p{L}\p{N}\p{M}]+/u)?.[0].toLowerCase() ?? ''
 
     setSelectableOptions([
@@ -168,7 +205,7 @@ const SearchBar = forwardRef<
       })),
       ...(profiles.length >= 5 ? [{ type: 'profiles', search }] : [])
     ] as TSearchParams[])
-  }, [input, debouncedInput, profiles])
+  }, [input, debouncedInput, profiles, isNmcSearch, nmcResolvedPubkey, isResolvingNmc])
 
   const list = useMemo(() => {
     if (selectableOptions.length <= 0) {
@@ -261,6 +298,17 @@ const SearchBar = forwardRef<
           }
           return null
         })}
+        {isResolvingNmc && (
+          <Item>
+            <div className="flex size-10 items-center justify-center">
+              <ShieldCheck className="flex-shrink-0 animate-pulse text-teal-500" />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col">
+              <div className="truncate font-semibold">{debouncedInput.trim()}</div>
+              <div className="text-sm text-muted-foreground">{t('Resolving Namecoin name...')}</div>
+            </div>
+          </Item>
+        )}
         {isFetchingProfiles && profiles.length < 5 && (
           <div className="px-2">
             <UserItemSkeleton hideFollowButton />
@@ -268,7 +316,7 @@ const SearchBar = forwardRef<
         )}
       </>
     )
-  }, [selectableOptions, selectedIndex, isFetchingProfiles, profiles])
+  }, [selectableOptions, selectedIndex, isFetchingProfiles, profiles, isResolvingNmc, debouncedInput])
 
   useEffect(() => {
     setDisplayList(searching && !!input)

--- a/src/hooks/useFetchNip05.tsx
+++ b/src/hooks/useFetchNip05.tsx
@@ -5,6 +5,7 @@ export function useFetchNip05(nip05?: string, pubkey?: string) {
   const [nip05IsVerified, setNip05IsVerified] = useState(false)
   const [nip05Name, setNip05Name] = useState<string>('')
   const [nip05Domain, setNip05Domain] = useState<string>('')
+  const [isNamecoin, setIsNamecoin] = useState(false)
   const [isFetching, setIsFetching] = useState(true)
 
   useEffect(() => {
@@ -12,13 +13,14 @@ export function useFetchNip05(nip05?: string, pubkey?: string) {
       setIsFetching(false)
       return
     }
-    verifyNip05(nip05, pubkey).then(({ isVerified, nip05Name, nip05Domain }) => {
-      setNip05IsVerified(isVerified)
-      setNip05Name(nip05Name)
-      setNip05Domain(nip05Domain)
+    verifyNip05(nip05, pubkey).then((result) => {
+      setNip05IsVerified(result.isVerified)
+      setNip05Name(result.nip05Name)
+      setNip05Domain(result.nip05Domain)
+      setIsNamecoin(result.isNamecoin ?? false)
       setIsFetching(false)
     })
   }, [nip05, pubkey])
 
-  return { nip05IsVerified, nip05Name, nip05Domain, isFetching }
+  return { nip05IsVerified, nip05Name, nip05Domain, isNamecoin, isFetching }
 }

--- a/src/lib/namecoin/constants.ts
+++ b/src/lib/namecoin/constants.ts
@@ -1,0 +1,37 @@
+/** Namecoin protocol constants */
+
+/**
+ * Default ElectrumX WebSocket servers for Namecoin.
+ *
+ * The browser connects directly via ws:// or wss:// — no backend proxy needed.
+ * On HTTPS pages, prefer wss:// first to avoid mixed-content blocks.
+ */
+export interface ElectrumxWsServer {
+  /** WebSocket URL (ws:// or wss://) */
+  url: string
+  /** Human-readable label */
+  label: string
+}
+
+export const DEFAULT_ELECTRUMX_SERVERS: ElectrumxWsServer[] =
+  typeof window !== 'undefined' && window.location?.protocol === 'https:'
+    ? [
+        { url: 'wss://electrumx.testls.space:50004', label: 'testls.space' },
+        { url: 'ws://electrumx.testls.space:50003', label: 'testls.space (plain)' }
+      ]
+    : [
+        { url: 'ws://electrumx.testls.space:50003', label: 'testls.space (plain)' },
+        { url: 'wss://electrumx.testls.space:50004', label: 'testls.space' }
+      ]
+
+/** Namecoin names expire after this many blocks without renewal (~250 days) */
+export const NAME_EXPIRE_DEPTH = 36000
+
+/** Cache TTL in ms (5 minutes) */
+export const DEFAULT_CACHE_TTL = 5 * 60 * 1000
+
+/** OP codes for Namecoin name scripts */
+export const OP_NAME_UPDATE = 0x53
+export const OP_2DROP = 0x6d
+export const OP_DROP = 0x75
+export const OP_RETURN = 0x6a

--- a/src/lib/namecoin/electrumx-ws.ts
+++ b/src/lib/namecoin/electrumx-ws.ts
@@ -1,0 +1,392 @@
+/**
+ * Browser-native ElectrumX WebSocket client for Namecoin name resolution.
+ *
+ * Connects directly from the browser to ElectrumX servers over WebSocket
+ * (ws:// or wss://) — no backend proxy or server-side code needed.
+ *
+ * Protocol: JSON-RPC 1.0 over WebSocket text frames (newline-delimited).
+ * ElectrumX 1.16.0+ with websockets support required on the server side.
+ *
+ * Resolution strategy:
+ * 1. Build a canonical name index script for the identifier
+ * 2. Compute the Electrum-style scripthash (reversed SHA-256)
+ * 3. Query blockchain.scripthash.get_history to find the latest tx
+ * 4. Fetch the verbose transaction and parse the name value from the script
+ * 5. Check current block height for name expiry
+ */
+
+import {
+  OP_NAME_UPDATE,
+  OP_2DROP,
+  OP_DROP,
+  OP_RETURN,
+  NAME_EXPIRE_DEPTH,
+  DEFAULT_ELECTRUMX_SERVERS,
+  type ElectrumxWsServer
+} from './constants'
+import type { NameShowResult } from './types'
+
+// ── Crypto helpers (Web Crypto API) ─────────────────────────────────
+
+/** SHA-256 hash using the browser's Web Crypto API */
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  if (!crypto?.subtle) {
+    throw new Error('crypto.subtle unavailable (insecure context?). Use https:// or localhost.')
+  }
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return new Uint8Array(hash)
+}
+
+/** Convert Uint8Array to hex string */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Convert hex string to Uint8Array */
+function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length
+  const arr = new Uint8Array(len / 2)
+  for (let i = 0; i < len; i += 2) {
+    arr[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+  }
+  return arr
+}
+
+// ── Script building ─────────────────────────────────────────────────
+
+/** Bitcoin-style push data encoding */
+function pushData(data: Uint8Array): Uint8Array {
+  const len = data.length
+  if (len === 0) {
+    return new Uint8Array([0x00])
+  }
+  if (len < 0x4c) {
+    const result = new Uint8Array(1 + len)
+    result[0] = len
+    result.set(data, 1)
+    return result
+  }
+  if (len <= 0xff) {
+    const result = new Uint8Array(2 + len)
+    result[0] = 0x4c // OP_PUSHDATA1
+    result[1] = len
+    result.set(data, 2)
+    return result
+  }
+  const result = new Uint8Array(3 + len)
+  result[0] = 0x4d // OP_PUSHDATA2
+  result[1] = len & 0xff
+  result[2] = (len >> 8) & 0xff
+  result.set(data, 3)
+  return result
+}
+
+/**
+ * Build the canonical name index script for ElectrumX lookup.
+ *
+ * Format: OP_NAME_UPDATE <push(name)> <push(empty)> OP_2DROP OP_DROP OP_RETURN
+ *
+ * This matches the script pattern indexed by the Namecoin ElectrumX fork
+ * (electrumx/lib/coins.py: NamecoinMixin.build_name_index_script).
+ */
+function buildNameIndexScript(nameBytes: Uint8Array): Uint8Array {
+  const namePush = pushData(nameBytes)
+  const emptyPush = pushData(new Uint8Array(0))
+
+  const result = new Uint8Array(1 + namePush.length + emptyPush.length + 3)
+  let offset = 0
+  result[offset++] = OP_NAME_UPDATE
+  result.set(namePush, offset)
+  offset += namePush.length
+  result.set(emptyPush, offset)
+  offset += emptyPush.length
+  result[offset++] = OP_2DROP
+  result[offset++] = OP_DROP
+  result[offset++] = OP_RETURN
+
+  return result
+}
+
+/**
+ * Compute the Electrum-style scripthash: SHA-256 of the script, byte-reversed, hex-encoded.
+ */
+async function electrumScripthash(script: Uint8Array): Promise<string> {
+  const hash = await sha256(script)
+  hash.reverse()
+  return toHex(hash)
+}
+
+// ── Transaction parsing ─────────────────────────────────────────────
+
+/** Read a push-data encoded byte sequence from script at pos */
+function readPushData(
+  script: Uint8Array,
+  pos: number
+): { data: Uint8Array; next: number } | null {
+  if (pos >= script.length) return null
+  const opcode = script[pos]
+
+  if (opcode === 0x00) {
+    return { data: new Uint8Array(0), next: pos + 1 }
+  }
+  if (opcode >= 0x01 && opcode <= 0x4b) {
+    const end = pos + 1 + opcode
+    if (end > script.length) return null
+    return { data: script.slice(pos + 1, end), next: end }
+  }
+  if (opcode === 0x4c) {
+    if (pos + 2 > script.length) return null
+    const len = script[pos + 1]
+    const end = pos + 2 + len
+    if (end > script.length) return null
+    return { data: script.slice(pos + 2, end), next: end }
+  }
+  if (opcode === 0x4d) {
+    if (pos + 3 > script.length) return null
+    const len = script[pos + 1] | (script[pos + 2] << 8)
+    const end = pos + 3 + len
+    if (end > script.length) return null
+    return { data: script.slice(pos + 3, end), next: end }
+  }
+  return null
+}
+
+interface VerboseTxVout {
+  scriptPubKey?: { hex?: string; asm?: string }
+}
+
+interface VerboseTxResult {
+  vout?: VerboseTxVout[]
+}
+
+/** Parse NAME_UPDATE name and value from a verbose transaction response */
+function parseNameFromVerboseTx(
+  txResult: VerboseTxResult,
+  expectedName: string
+): { name: string; value: string } | null {
+  const nameBytes = new TextEncoder().encode(expectedName)
+
+  for (const vout of txResult.vout || []) {
+    const hex = vout.scriptPubKey?.hex
+    if (!hex || !hex.startsWith('53')) continue // Must start with OP_NAME_UPDATE
+
+    const script = hexToBytes(hex)
+    if (script[0] !== OP_NAME_UPDATE) continue
+
+    const nameParsed = readPushData(script, 1)
+    if (!nameParsed) continue
+
+    if (nameParsed.data.length !== nameBytes.length) continue
+    let match = true
+    for (let i = 0; i < nameBytes.length; i++) {
+      if (nameParsed.data[i] !== nameBytes[i]) {
+        match = false
+        break
+      }
+    }
+    if (!match) continue
+
+    const valueParsed = readPushData(script, nameParsed.next)
+    if (!valueParsed) continue
+
+    const name = new TextDecoder('ascii').decode(nameParsed.data)
+    const value = new TextDecoder('utf-8').decode(valueParsed.data)
+    return { name, value }
+  }
+  return null
+}
+
+// ── WebSocket JSON-RPC client ───────────────────────────────────────
+
+interface HistoryEntry {
+  tx_hash: string
+  height: number
+}
+
+interface RpcResponse {
+  jsonrpc?: string
+  id: number
+  result?: unknown
+  error?: { code: number; message: string }
+}
+
+/**
+ * Batch multiple JSON-RPC calls over a single WebSocket connection.
+ * Sends requests sequentially but keeps the socket open until all are done.
+ */
+function wsRpcBatch(
+  url: string,
+  calls: Array<{ method: string; params: unknown[] }>,
+  timeoutMs = 20000
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const results: unknown[] = []
+    let callIndex = 0
+    const ws = new WebSocket(url)
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true
+        ws.close()
+        reject(new Error(`WebSocket batch timeout after ${timeoutMs}ms`))
+      }
+    }, timeoutMs)
+
+    ws.addEventListener('open', () => {
+      sendNext()
+    })
+
+    function sendNext() {
+      if (callIndex >= calls.length) return
+      const { method, params } = calls[callIndex]
+      ws.send(JSON.stringify({ jsonrpc: '2.0', method, params, id: callIndex + 1 }) + '\n')
+    }
+
+    ws.addEventListener('message', (ev) => {
+      if (settled) return
+      try {
+        const data = typeof ev.data === 'string' ? ev.data : String(ev.data)
+        const msg: RpcResponse = JSON.parse(data.trim())
+        if (msg.error) {
+          settled = true
+          clearTimeout(timer)
+          ws.close()
+          reject(new Error(msg.error.message || `RPC error ${msg.error.code}`))
+          return
+        }
+        results.push(msg.result)
+        callIndex++
+        if (callIndex >= calls.length) {
+          settled = true
+          clearTimeout(timer)
+          ws.close()
+          resolve(results)
+        } else {
+          sendNext()
+        }
+      } catch (err) {
+        settled = true
+        clearTimeout(timer)
+        ws.close()
+        reject(err)
+      }
+    })
+
+    ws.addEventListener('error', () => {
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        reject(new Error(`WebSocket connection failed: ${url}`))
+      }
+    })
+
+    ws.addEventListener('close', (ev) => {
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        reject(new Error(`WebSocket closed unexpectedly: code=${ev.code}`))
+      }
+    })
+  })
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Resolve a Namecoin name via WebSocket to an ElectrumX server.
+ *
+ * Connects directly from the browser — no proxy needed.
+ * Uses a single WebSocket connection for all RPCs in the lookup sequence.
+ *
+ * @param fullName  The Namecoin name, e.g. "d/example" or "id/alice"
+ * @param serverUrl WebSocket URL of the ElectrumX server
+ * @returns NameShowResult if found, null if the name doesn't exist
+ */
+export async function nameShowWs(
+  fullName: string,
+  serverUrl?: string
+): Promise<NameShowResult | null> {
+  const url = serverUrl || DEFAULT_ELECTRUMX_SERVERS[0].url
+
+  // 1. Compute scripthash
+  const nameBytes = new TextEncoder().encode(fullName)
+  const script = buildNameIndexScript(nameBytes)
+  const scripthash = await electrumScripthash(script)
+
+  // 2. Negotiate version + get history in one connection
+  const batch1Results = (await wsRpcBatch(url, [
+    { method: 'server.version', params: ['jumble/0.1', '1.4'] },
+    { method: 'blockchain.scripthash.get_history', params: [scripthash] }
+  ])) as [unknown, HistoryEntry[]]
+
+  const history = batch1Results[1]
+  if (!history || !history.length) return null
+
+  // 3. Get latest transaction + current block height
+  const latest = history.reduce((a, b) => (a.height > b.height ? a : b))
+
+  const batch2Results = (await wsRpcBatch(url, [
+    { method: 'blockchain.transaction.get', params: [latest.tx_hash, true] },
+    { method: 'blockchain.headers.subscribe', params: [] }
+  ])) as [VerboseTxResult, { height?: number; block_height?: number }]
+
+  const txResult = batch2Results[0]
+  const headersResult = batch2Results[1]
+  const currentHeight = headersResult?.height || headersResult?.block_height || 0
+
+  // 4. Check expiry
+  const expired =
+    currentHeight > 0 && latest.height > 0 && currentHeight - latest.height >= NAME_EXPIRE_DEPTH
+  if (expired) {
+    return {
+      name: fullName,
+      value: '',
+      txid: latest.tx_hash,
+      height: latest.height,
+      expired: true,
+      expiresIn: 0
+    }
+  }
+
+  // 5. Parse name value from transaction
+  const parsed = parseNameFromVerboseTx(txResult, fullName)
+  if (!parsed) return null
+
+  const expiresIn =
+    currentHeight > 0 && latest.height > 0
+      ? NAME_EXPIRE_DEPTH - (currentHeight - latest.height)
+      : undefined
+
+  return {
+    name: parsed.name,
+    value: parsed.value,
+    txid: latest.tx_hash,
+    height: latest.height,
+    expired: false,
+    expiresIn
+  }
+}
+
+/**
+ * Try multiple servers in order until one succeeds.
+ */
+export async function nameShowWithFallback(
+  fullName: string,
+  servers?: ElectrumxWsServer[]
+): Promise<NameShowResult | null> {
+  const serverList = servers || DEFAULT_ELECTRUMX_SERVERS
+  let lastError: Error | null = null
+
+  for (const server of serverList) {
+    try {
+      return await nameShowWs(fullName, server.url)
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err))
+      console.warn(`[Namecoin] Server ${server.label} failed:`, lastError.message)
+    }
+  }
+
+  throw lastError || new Error('All ElectrumX servers unreachable')
+}

--- a/src/lib/namecoin/index.ts
+++ b/src/lib/namecoin/index.ts
@@ -1,0 +1,8 @@
+export {
+  isNamecoinIdentifier,
+  parseNamecoinIdentifier,
+  resolveNamecoin
+} from './resolver'
+export type { ParsedNamecoinIdentifier, NamecoinNostrResult, NameShowResult } from './types'
+export { DEFAULT_ELECTRUMX_SERVERS, NAME_EXPIRE_DEPTH } from './constants'
+export { nameShowWs, nameShowWithFallback } from './electrumx-ws'

--- a/src/lib/namecoin/resolver.ts
+++ b/src/lib/namecoin/resolver.ts
@@ -1,0 +1,213 @@
+/**
+ * Namecoin NIP-05 identity resolver
+ *
+ * Resolves .bit domains, d/ and id/ Namecoin names to Nostr pubkeys
+ * by connecting directly to ElectrumX servers via WebSocket from the browser.
+ *
+ * No backend proxy needed — the browser connects to ElectrumX over ws:// or wss://
+ * and performs the full scripthash-based name lookup natively.
+ */
+
+import { LRUCache } from 'lru-cache'
+import type { ParsedNamecoinIdentifier, NamecoinNostrResult } from './types'
+import { DEFAULT_CACHE_TTL } from './constants'
+import { nameShowWithFallback } from './electrumx-ws'
+
+// ── Identifier detection & parsing ──────────────────────────────────
+
+/** Check if a NIP-05-style address is a Namecoin identifier */
+export function isNamecoinIdentifier(address: string): boolean {
+  if (!address) return false
+  const lower = address.toLowerCase()
+  return lower.endsWith('.bit') || lower.startsWith('d/') || lower.startsWith('id/')
+}
+
+/**
+ * Parse a NIP-05 address or raw Namecoin name into its components.
+ *
+ * Supported formats:
+ *  - alice@example.bit  → d/example, localPart=alice
+ *  - _@example.bit      → d/example, root
+ *  - example.bit        → d/example, root
+ *  - d/example          → d/example, root
+ *  - id/alice           → id/alice
+ */
+export function parseNamecoinIdentifier(raw: string): ParsedNamecoinIdentifier | null {
+  if (!raw) return null
+  const input = raw.trim().toLowerCase()
+
+  // Direct namespace format: d/name or id/name
+  if (input.startsWith('d/')) {
+    const name = input.slice(2)
+    if (!name) return null
+    return { namecoinName: `d/${name}`, namespace: 'd', name, originalAddress: raw }
+  }
+  if (input.startsWith('id/')) {
+    const name = input.slice(3)
+    if (!name) return null
+    return { namecoinName: `id/${name}`, namespace: 'id', name, originalAddress: raw }
+  }
+
+  // NIP-05 style: [user@]domain.bit
+  if (input.endsWith('.bit')) {
+    const atIndex = input.indexOf('@')
+    let localPart: string | undefined
+    let domain: string
+
+    if (atIndex !== -1) {
+      localPart = input.slice(0, atIndex)
+      domain = input.slice(atIndex + 1)
+      if (localPart === '_') localPart = undefined
+    } else {
+      domain = input
+    }
+
+    const name = domain.slice(0, -4) // remove ".bit"
+    if (!name) return null
+
+    return {
+      namecoinName: `d/${name}`,
+      namespace: 'd',
+      name,
+      localPart,
+      originalAddress: raw
+    }
+  }
+
+  return null
+}
+
+// ── LRU Cache ───────────────────────────────────────────────────────
+
+const SENTINEL_NOT_FOUND: NamecoinNostrResult = { pubkey: '' }
+
+const cache = new LRUCache<string, NamecoinNostrResult>({
+  max: 200,
+  ttl: DEFAULT_CACHE_TTL
+})
+
+// ── WebSocket resolution ────────────────────────────────────────────
+
+/**
+ * Resolve a parsed Namecoin identifier via WebSocket to ElectrumX.
+ * Connects directly from the browser — no proxy needed.
+ * Returns null if the name doesn't exist or has no Nostr data.
+ */
+async function resolveNamecoinViaWs(
+  parsed: ParsedNamecoinIdentifier
+): Promise<NamecoinNostrResult | null> {
+  const result = await nameShowWithFallback(parsed.namecoinName)
+  if (!result || result.expired) return null
+
+  const value = result.value
+  if (!value) return null
+
+  let parsedValue: Record<string, unknown>
+  try {
+    parsedValue = typeof value === 'string' ? JSON.parse(value) : value
+  } catch {
+    return null
+  }
+
+  return extractNostrData(parsedValue, parsed)
+}
+
+/**
+ * Extract Nostr pubkey and relays from a Namecoin name value.
+ *
+ * d/ namespace format:
+ *   {"nostr": {"names": {"alice": "hex64"}, "relays": {"hex64": ["wss://..."]}}}
+ *   {"nostr": "hex64"}  (shorthand, root identity)
+ *
+ * id/ namespace format:
+ *   {"nostr": "hex64"}
+ *   {"nostr": {"pubkey": "hex64", "relays": ["wss://..."]}}
+ */
+function extractNostrData(
+  value: Record<string, unknown>,
+  parsed: ParsedNamecoinIdentifier
+): NamecoinNostrResult | null {
+  const nostr = value.nostr
+  if (!nostr) return null
+
+  // id/ namespace
+  if (parsed.namespace === 'id') {
+    if (typeof nostr === 'string' && isValidHexPubkey(nostr)) {
+      return { pubkey: nostr }
+    }
+    if (typeof nostr === 'object' && nostr !== null) {
+      const obj = nostr as Record<string, unknown>
+      const pubkey = obj.pubkey
+      if (typeof pubkey === 'string' && isValidHexPubkey(pubkey)) {
+        const relays = Array.isArray(obj.relays) ? (obj.relays as string[]) : undefined
+        return { pubkey, relays }
+      }
+    }
+    return null
+  }
+
+  // d/ namespace
+  if (typeof nostr === 'string' && isValidHexPubkey(nostr)) {
+    if (!parsed.localPart) return { pubkey: nostr }
+    return null
+  }
+
+  if (typeof nostr === 'object' && nostr !== null) {
+    const obj = nostr as Record<string, unknown>
+    const names = obj.names as Record<string, string> | undefined
+    if (!names) return null
+
+    const lookupKey = parsed.localPart || '_'
+    let pubkey = names[lookupKey]
+
+    // Fallback: bare domain with no "_" entry — use sole entry if exactly one
+    if (!pubkey && !parsed.localPart) {
+      const entries = Object.entries(names).filter(([, v]) => isValidHexPubkey(v))
+      if (entries.length === 1) {
+        pubkey = entries[0][1]
+      }
+    }
+
+    if (!pubkey || !isValidHexPubkey(pubkey)) return null
+
+    const relaysMap = obj.relays as Record<string, string[]> | undefined
+    const relays = relaysMap?.[pubkey]
+
+    return { pubkey, relays: relays?.length ? relays : undefined }
+  }
+
+  return null
+}
+
+function isValidHexPubkey(s: string): boolean {
+  return /^[0-9a-f]{64}$/.test(s)
+}
+
+// ── Main resolution function ────────────────────────────────────────
+
+/**
+ * Resolve a Namecoin identifier to a Nostr pubkey.
+ * Uses an in-memory LRU cache and direct WebSocket connection to ElectrumX.
+ */
+export async function resolveNamecoin(
+  address: string
+): Promise<NamecoinNostrResult | null> {
+  const parsed = parseNamecoinIdentifier(address)
+  if (!parsed) return null
+
+  const cacheKey = parsed.localPart
+    ? `${parsed.namecoinName}:${parsed.localPart}`
+    : parsed.namecoinName
+
+  const cached = cache.get(cacheKey)
+  if (cached !== undefined) return cached === SENTINEL_NOT_FOUND ? null : cached
+
+  try {
+    const result = await resolveNamecoinViaWs(parsed)
+    cache.set(cacheKey, result ?? SENTINEL_NOT_FOUND)
+    return result
+  } catch (err) {
+    console.warn('[Namecoin] Resolution failed for', address, err)
+    return null
+  }
+}

--- a/src/lib/namecoin/types.ts
+++ b/src/lib/namecoin/types.ts
@@ -1,0 +1,37 @@
+/** Namecoin NIP-05 identity resolution types */
+
+/** Result of resolving a Namecoin name's Nostr data */
+export interface NamecoinNostrResult {
+  pubkey: string
+  relays?: string[]
+}
+
+/** Parsed Namecoin identifier */
+export interface ParsedNamecoinIdentifier {
+  /** The raw Namecoin name, e.g. "d/example" or "id/alice" */
+  namecoinName: string
+  /** Namespace: "d" (domain) or "id" (identity) */
+  namespace: 'd' | 'id'
+  /** The name within the namespace, e.g. "example" */
+  name: string
+  /** Local part for domain namespace (from user@domain.bit), undefined for root */
+  localPart?: string
+  /** Original NIP-05 style address if applicable */
+  originalAddress?: string
+}
+
+/** Result from ElectrumX name resolution */
+export interface NameShowResult {
+  /** The Namecoin name (e.g. "d/example") */
+  name: string
+  /** The name's current value (JSON string) */
+  value: string
+  /** Transaction ID of the latest name_update */
+  txid: string
+  /** Block height of the latest name_update */
+  height: number
+  /** Whether the name has expired (>36000 blocks since last update) */
+  expired: boolean
+  /** Blocks until expiry, or undefined if current height is unknown */
+  expiresIn?: number
+}

--- a/src/lib/nip05.ts
+++ b/src/lib/nip05.ts
@@ -1,10 +1,12 @@
 import { LRUCache } from 'lru-cache'
+import { isNamecoinIdentifier, resolveNamecoin } from './namecoin'
 import { isValidPubkey } from './pubkey'
 
 type TVerifyNip05Result = {
   isVerified: boolean
   nip05Name: string
   nip05Domain: string
+  isNamecoin?: boolean
 }
 
 const verifyNip05ResultCache = new LRUCache<string, TVerifyNip05Result>({
@@ -16,14 +18,54 @@ const verifyNip05ResultCache = new LRUCache<string, TVerifyNip05Result>({
 })
 
 async function _verifyNip05(nip05: string, pubkey: string): Promise<TVerifyNip05Result> {
+  // Route Namecoin identifiers (.bit / d/ / id/) to blockchain resolver
+  if (isNamecoinIdentifier(nip05)) {
+    return _verifyNamecoin(nip05, pubkey)
+  }
+
   const [nip05Name, nip05Domain] = nip05?.split('@') || [undefined, undefined]
-  const result = { isVerified: false, nip05Name, nip05Domain }
+  const result: TVerifyNip05Result = { isVerified: false, nip05Name, nip05Domain }
   if (!nip05Name || !nip05Domain || !pubkey) return result
 
   try {
     const res = await fetch(getWellKnownNip05Url(nip05Domain, nip05Name))
     const json = await res.json()
     if (json.names?.[nip05Name] === pubkey) {
+      return { ...result, isVerified: true }
+    }
+  } catch {
+    // ignore
+  }
+  return result
+}
+
+async function _verifyNamecoin(nip05: string, pubkey: string): Promise<TVerifyNip05Result> {
+  const lower = nip05.toLowerCase()
+  let nip05Name: string
+  let nip05Domain: string
+
+  if (lower.includes('@')) {
+    const [name, domain] = lower.split('@')
+    nip05Name = name === '_' ? '_' : name
+    nip05Domain = domain
+  } else if (lower.startsWith('d/') || lower.startsWith('id/')) {
+    nip05Name = '_'
+    nip05Domain = lower
+  } else {
+    nip05Name = '_'
+    nip05Domain = lower
+  }
+
+  const result: TVerifyNip05Result = {
+    isVerified: false,
+    nip05Name,
+    nip05Domain,
+    isNamecoin: true
+  }
+
+  try {
+    const resolved = await resolveNamecoin(nip05)
+    if (resolved && resolved.pubkey === pubkey) {
       return { ...result, isVerified: true }
     }
   } catch {


### PR DESCRIPTION
Add decentralised NIP-05 identity verification via Namecoin blockchain, enabling `.bit` domain identities without centralised HTTP servers.

## What this does

The browser connects directly to ElectrumX servers over WebSocket (ws:// / wss://) to resolve Namecoin names — **no backend proxy or server-side code needed**. Jumble remains a fully static web app.

### Changes

**New: `src/lib/namecoin/`** — self-contained Namecoin resolution module:
- `electrumx-ws.ts` — Browser-native WebSocket JSON-RPC client for ElectrumX. Computes scripthash via Web Crypto API (SHA-256), queries `blockchain.scripthash.get_history`, fetches verbose transactions, parses `NAME_UPDATE` scripts, and checks block height for name expiry (36,000 blocks ≈ 250 days).
- `resolver.ts` — Identifier parser + Nostr data extractor with LRU cache (200 entries, 5 min TTL). Handles all identifier formats and both `d/` and `id/` namespace JSON structures.
- `constants.ts` — Protocol constants, default server list (auto-selects wss:// on HTTPS pages)
- `types.ts` — TypeScript interfaces

**Modified: NIP-05 verification pipeline:**
- `src/lib/nip05.ts` — Intercepts `.bit` / `d/` / `id/` identifiers before HTTP fetch, routes to blockchain resolver. Returns `isNamecoin` flag.
- `src/hooks/useFetchNip05.tsx` — Exposes `isNamecoin` boolean for UI differentiation.
- `src/components/Nip05/index.tsx` — Namecoin-verified identities show a teal shield icon (`ShieldCheck`) instead of the standard favicon/badge, making blockchain verification visually distinct.

**Modified: Search bar:**
- `src/components/SearchBar/index.tsx` — Detects `.bit` / `d/` / `id/` input, resolves via ElectrumX in real-time, and shows the resolved profile directly. Shows animated loading state during resolution.

### Supported identifier formats

| Input | Namecoin name | Lookup |
|---|---|---|
| `alice@example.bit` | `d/example` | localPart=alice |
| `_@example.bit` / `example.bit` | `d/example` | root identity |
| `d/example` | `d/example` | direct lookup |
| `id/alice` | `id/alice` | identity namespace |

### JSON structure

Reads the same Nostr pubkey/relay JSON structure used by [Amethyst](https://github.com/vitorpamplona/amethyst) and other Nostr clients:

```json
{
  "nostr": {
    "names": { "_": "<hex-pubkey>", "alice": "<hex-pubkey>" },
    "relays": { "<hex-pubkey>": ["wss://relay.example.com"] }
  }
}
```

### How it works

1. Parse identifier → determine Namecoin name (`d/example`)
2. Build canonical name index script (OP_NAME_UPDATE pattern)
3. SHA-256 → reversed hex scripthash
4. WebSocket → ElectrumX `blockchain.scripthash.get_history`
5. Fetch verbose transaction → parse NAME_UPDATE value from script
6. Check block height for expiry
7. Extract Nostr pubkey + relays from JSON value

### Testing

- TypeScript: clean compile (`tsc --noEmit` passes)
- ESLint: clean
- Build: clean (`npm run build` succeeds)
- Tested with `electrumx.testls.space` (wss://:50004, ws://:50003)
- Verified: `d/bitcoin`, `d/testls` resolve correctly

### Related

Based on the approach from https://github.com/hzrd149/nostrudel/pull/352 (noStrudel Namecoin integration). Same pattern has been applied to [Iris](https://github.com/irislib/iris-client), [Snort](https://github.com/v0l/snort), and [Coracle](https://github.com/coracle-social/coracle).