### PR TITLE
feat: treat onion URLs as secure when onion services are enabled

### DIFF
--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,3 +1,5 @@
+import storage from '@/services/local-storage.service'
+
 export function isWebsocketUrl(url: string): boolean {
   try {
     const protocol = new URL(url).protocol
@@ -8,6 +10,11 @@ export function isWebsocketUrl(url: string): boolean {
 }
 
 export function isInsecureUrl(url: string): boolean {
+  // If onion services are enabled, consider them secure
+  if (!storage.getFilterOutOnionRelays() && isOnionUrl(url)) {
+    return false
+  }
+
   try {
     const protocol = new URL(url).protocol
     return protocol === 'ws:' || protocol === 'http:'


### PR DESCRIPTION
Before this change, you have to enable "Allow insecure connections" to use onion relays, even that "Filter out onion relays" is disabled