### PR TITLE
feat(pulse): add deep per-author Pulse with backfill beyond 24h

### DIFF
--- a/src/components/DeepPulseList/index.tsx
+++ b/src/components/DeepPulseList/index.tsx
@@ -1,0 +1,1201 @@
+import { FormattedTimestamp } from '@/components/FormattedTimestamp'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import UserAvatar, { SimpleUserAvatar, UserAvatarSkeleton } from '@/components/UserAvatar'
+import Username, { SimpleUsername } from '@/components/Username'
+import { isMentioningMutedUsers } from '@/lib/event'
+import { toNote, toUserAggregationDetail } from '@/lib/link'
+import { getDefaultRelayUrls } from '@/lib/relay'
+import { mergeTimelines } from '@/lib/timeline'
+import { cn, isTouchDevice } from '@/lib/utils'
+import { useSecondaryPage } from '@/PageManager'
+import { useContentPolicy } from '@/providers/ContentPolicyProvider'
+import { useDeletedEvent } from '@/providers/DeletedEventProvider'
+import { useMuteList } from '@/providers/MuteListProvider'
+import { useNostr } from '@/providers/NostrProvider'
+import { usePageActive } from '@/providers/PageActiveProvider'
+import { usePinnedUsers } from '@/providers/PinnedUsersProvider'
+import { useUserTrust } from '@/providers/UserTrustProvider'
+import { PULSE_EVENTS_PER_USER_CAP } from '@/lib/pulse'
+import client from '@/services/client.service'
+import indexedDb from '@/services/indexed-db.service'
+import threadService from '@/services/thread.service'
+import userAggregationService, { TUserAggregation } from '@/services/user-aggregation.service'
+import { TFeedSubRequest } from '@/types'
+import dayjs from 'dayjs'
+import { History, Loader, Star } from 'lucide-react'
+import { Event, Filter, kinds } from 'nostr-tools'
+import { planBackfillRound } from '../UserAggregationList/pulse-backfill'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import PullToRefresh from '@/components/PullToRefresh'
+import { toast } from 'sonner'
+import { LoadingBar } from '../LoadingBar'
+import NewNotesButton from '../NewNotesButton'
+import TrustScoreBadge from '../TrustScoreBadge'
+
+const LIMIT = 500
+const SHOW_COUNT = 20
+// Cap on how many per-author backfill rounds we run after the initial EOSE.
+const MAX_BACKFILL_ROUNDS = 2
+// Max concurrent backfill REQs in flight. Low on purpose — browsers cap
+// WebSocket connections and relays (damus, nos.lol, etc.) cap concurrent
+// REQs per client. Going higher triggers "too many concurrent REQs" NOTICEs
+// and "Insufficient resources" WS failures.
+const BACKFILL_CONCURRENCY = 6
+// When batching fresh-author queries into per-relay REQs, cap authors per
+// REQ so relays don't reject filter-too-large.
+const AUTHORS_PER_BATCHED_REQ = 50
+// Buckets `since` values into 1-hour windows so we can coalesce authors
+// checked "around the same time" into a single REQ. The REQ uses the
+// minimum since in the bucket — worst case we get a few extra events.
+const SINCE_BUCKET_SECONDS = 3600
+
+export type TDeepPulseListRef = {
+  scrollToTop: (behavior?: ScrollBehavior) => void
+  refresh: () => void
+}
+
+const DeepPulseList = forwardRef<
+  TDeepPulseListRef,
+  {
+    subRequests: TFeedSubRequest[]
+    showKinds?: number[]
+    filterMutedNotes?: boolean
+    areAlgoRelays?: boolean
+    showRelayCloseReason?: boolean
+    isPubkeyFeed?: boolean
+    trustScoreThreshold?: number
+  }
+>(
+  (
+    {
+      subRequests,
+      showKinds,
+      filterMutedNotes = true,
+      areAlgoRelays = false,
+      showRelayCloseReason = false,
+      isPubkeyFeed = false,
+      trustScoreThreshold
+    },
+    ref
+  ) => {
+    const { t } = useTranslation()
+    const active = usePageActive()
+    const { pubkey: currentPubkey, startLogin } = useNostr()
+    const { push } = useSecondaryPage()
+    const { mutePubkeySet } = useMuteList()
+    const { pinnedPubkeySet } = usePinnedUsers()
+    const { meetsMinTrustScore } = useUserTrust()
+    const { hideContentMentioningMutedUsers } = useContentPolicy()
+    const { isEventDeleted } = useDeletedEvent()
+    // `since` is no longer a hard time-window filter. It only tracks the
+    // oldest timestamp we've loaded so we can show a "Last X days" hint.
+    // The initial guess is 24h ago; it gets pushed backward as backfill
+    // loads older events per-user.
+    const [since, setSince] = useState(() => dayjs().subtract(1, 'day').unix())
+    const [storedEvents, setStoredEvents] = useState<Event[]>([])
+    const [events, setEvents] = useState<Event[]>([])
+    const [filteredEvents, setFilteredEvents] = useState<Event[]>([])
+    const [newEvents, setNewEvents] = useState<Event[]>([])
+    const [filteredNewEvents, setFilteredNewEvents] = useState<Event[]>([])
+    const [newEventPubkeys, setNewEventPubkeys] = useState<Set<string>>(new Set())
+    const [loading, setLoading] = useState(true)
+    const [backfilling, setBackfilling] = useState(false)
+    const [backfillExhausted, setBackfillExhausted] = useState(false)
+    const [showLoadingBar, setShowLoadingBar] = useState(true)
+    const [refreshCount, setRefreshCount] = useState(0)
+    const [showCount, setShowCount] = useState(SHOW_COUNT)
+    // Track pubkeys that still need backfill and the per-author floor we've
+    // already queried, so "Load earlier" can keep going without re-querying.
+    const backfillFloorRef = useRef<Map<string, number>>(new Map())
+    // Authors whose own write relays we've already queried without finding
+    // anything. Used to avoid re-issuing per-author fresh queries each round.
+    const freshTriedRef = useRef<Set<string>>(new Set())
+    // Per-author `lastCheckedAt` loaded from IDB at mount. The planner uses
+    // this to send `since: lastCheckedAt` instead of an unbounded fetch for
+    // authors we've successfully checked before. Populated by the hydration
+    // effect; updated in-memory after each successful per-author query so
+    // subsequent rounds in the same session don't ask for overlapping ranges.
+    const sinceByAuthorRef = useRef<Map<string, number>>(new Map())
+    const supportTouch = useMemo(() => isTouchDevice(), [])
+    const feedId = useMemo(() => {
+      return userAggregationService.getFeedId(subRequests, showKinds)
+    }, [JSON.stringify(subRequests), JSON.stringify(showKinds)])
+    const bottomRef = useRef<HTMLDivElement | null>(null)
+    const topRef = useRef<HTMLDivElement | null>(null)
+    const nonPinnedTopRef = useRef<HTMLDivElement | null>(null)
+    const sinceRef = useRef<number | undefined>(undefined)
+    sinceRef.current = newEvents.length
+      ? newEvents[0].created_at + 1
+      : events.length
+        ? events[0].created_at + 1
+        : undefined
+
+    const scrollToTop = (behavior: ScrollBehavior = 'instant') => {
+      setTimeout(() => {
+        topRef.current?.scrollIntoView({ behavior, block: 'start' })
+      }, 20)
+    }
+
+    const refresh = () => {
+      scrollToTop()
+      setTimeout(() => {
+        setRefreshCount((count) => count + 1)
+      }, 500)
+    }
+
+    useImperativeHandle(ref, () => ({ scrollToTop, refresh }), [])
+
+    // Register the effective kinds for this feed so the per-author detail
+    // page can subscribe with the same filter. Without this it surfaces
+    // every kind the author posts — kind 30618, cashu events, etc. — which
+    // the user never asked for.
+    useEffect(() => {
+      userAggregationService.setFeedKinds(feedId, showKinds ?? [])
+    }, [feedId, JSON.stringify(showKinds)])
+
+    useEffect(() => {
+      return () => {
+        userAggregationService.clearAggregations(feedId)
+      }
+    }, [feedId])
+
+    useEffect(() => {
+      if (!subRequests.length) return
+
+      sinceRef.current = undefined
+      setSince(dayjs().subtract(1, 'day').unix())
+      setStoredEvents([])
+      setEvents([])
+      setNewEvents([])
+      setBackfilling(false)
+      setBackfillExhausted(false)
+      backfillFloorRef.current = new Map()
+      freshTriedRef.current = new Set()
+      sinceByAuthorRef.current = new Map()
+
+      // Instant hydration from the Pulse IDB cache so inactive follows show
+      // their last known posts while the live subscription catches up.
+      // Cody's point: browser WS limits make live fetching of hundreds of
+      // follows fragile; the cache bridges the gap for older posts.
+      //
+      // Also load per-author metadata (lastCheckedAt) so the backfill sends
+      // `since: lastCheckedAt` instead of refetching the whole timeline.
+      let cancelled = false
+      const authors = subRequests.flatMap(({ filter }) => filter.authors ?? [])
+      if (authors.length > 0) {
+        // Hydrate events and meta independently. If one call fails (e.g. the
+        // meta store doesn't exist yet on an in-progress schema upgrade),
+        // the other still succeeds — the UI at least paints from cache.
+        indexedDb
+          .getPulseEventsForAuthors(authors, PULSE_EVENTS_PER_USER_CAP)
+          .then((cached) => {
+            if (cancelled || cached.length === 0) return
+            // Filter cached events to the active kinds. The IDB cache can
+            // contain kinds the user has since disabled (e.g. reactions that
+            // an older build of UserAggregationDetailPage persisted by
+            // streaming all kinds). Filtering on read makes the feed
+            // self-heal without an explicit migration.
+            const kindsSet = showKinds && showKinds.length > 0
+              ? new Set(showKinds)
+              : null
+            const filtered = kindsSet
+              ? cached.filter((e) => kindsSet.has(e.kind))
+              : cached
+            if (filtered.length === 0) return
+            const sorted = [...filtered].sort(
+              (a, b) => b.created_at - a.created_at
+            )
+            setEvents((prev) => mergeTimelines([sorted, prev]))
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn('[Pulse] event cache hydration failed:', err)
+          })
+
+        indexedDb
+          .getPulseAuthorMeta(authors)
+          .then((meta) => {
+            if (cancelled) return
+            for (const [pubkey, m] of meta) {
+              if (m.lastCheckOk && m.lastCheckedAt > 0) {
+                sinceByAuthorRef.current.set(pubkey, m.lastCheckedAt)
+              }
+            }
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn('[Pulse] author meta hydration failed:', err)
+          })
+      }
+      return () => {
+        cancelled = true
+      }
+    }, [feedId, refreshCount])
+
+    // Per-author backfill: after the initial EOSE, fetch older events for
+    // authors with fewer than PULSE_EVENTS_PER_USER_CAP events. The actual
+    // query planning lives in pulse-backfill.ts so it can be unit-tested;
+    // this function handles execution, state wiring and floor bookkeeping.
+    const runBackfill = useCallback(
+      async (seedEvents: Event[], deeper = false) => {
+        const allAuthors = new Set(
+          subRequests.flatMap(({ filter }) => filter.authors ?? [])
+        )
+        if (allAuthors.size === 0) return
+
+        setBackfilling(true)
+        userAggregationService.setBackfilling(feedId, true)
+        setBackfillExhausted(false)
+        try {
+          let accumulated = seedEvents
+          let totalFetched = 0
+
+          for (let round = 0; round < MAX_BACKFILL_ROUNDS; round++) {
+            const plan = planBackfillRound({
+              subRequests,
+              showKinds: showKinds ?? [],
+              accumulated,
+              perUserCap: PULSE_EVENTS_PER_USER_CAP,
+              floors: backfillFloorRef.current,
+              freshTried: freshTriedRef.current,
+              sinceByAuthor: sinceByAuthorRef.current,
+              deeper,
+              freshLimit: 1000,
+              partialLimit: PULSE_EVENTS_PER_USER_CAP
+            })
+            if (plan.queries.length === 0) break
+
+            // Resolve relays per query. Fetch relay lists in parallel so
+            // hundreds of authors don't serialize one fetchRelayList at a
+            // time (IDB-cached internally, but still worth batching).
+            const resolved = await Promise.all(
+              plan.queries.map(async (q) => {
+                if ((q.kind === 'partial' || q.kind === 'fresh-author') && q.pubkey) {
+                  const relayList = await client.fetchRelayList(q.pubkey)
+                  const merged = Array.from(
+                    new Set([
+                      ...q.urls,
+                      ...relayList.write,
+                      ...getDefaultRelayUrls()
+                    ])
+                  ).slice(0, 8)
+                  return { ...q, urls: merged }
+                }
+                const urls = q.urls.length
+                  ? q.urls
+                  : await client.determineRelaysByFilter(q.filter)
+                return { ...q, urls }
+              })
+            )
+
+            // Stream results into state as each query resolves so the UI
+            // updates progressively instead of waiting for the whole round.
+            const existingIds = new Set(accumulated.map((e) => e.id))
+            let fetchedTotal = 0
+            const commitEvents = (evts: Event[]) => {
+              const fresh: Event[] = []
+              for (const e of evts) {
+                if (existingIds.has(e.id)) continue
+                existingIds.add(e.id)
+                fresh.push(e)
+              }
+              if (fresh.length === 0) return
+              fetchedTotal += fresh.length
+              accumulated = [...accumulated, ...fresh].sort(
+                (a, b) => b.created_at - a.created_at
+              )
+              // CRITICAL: merge into current state (which includes the
+              // IDB-hydrated events) rather than replacing it. Previously we
+              // called setEvents(accumulated), which wiped the cache on the
+              // first commit because `accumulated` only contained the fresh
+              // subscription + backfill events, not the cached ones.
+              setEvents((prev) => mergeTimelines([accumulated, prev]))
+            }
+
+            const freshQ = resolved.filter((q) => q.kind === 'fresh')
+            const freshAuthorQ = resolved.filter((q) => q.kind === 'fresh-author')
+            // Partial queries stay per-author: each one carries an
+            // author-specific `until` that can't be coalesced with others.
+            const partialQ = resolved
+              .filter((q) => q.kind === 'partial')
+              .sort((a, b) => {
+                const aPinned = a.pubkey && pinnedPubkeySet.has(a.pubkey) ? 1 : 0
+                const bPinned = b.pubkey && pinnedPubkeySet.has(b.pubkey) ? 1 : 0
+                return bPinned - aPinned
+              })
+
+            // Coalesce fresh-author queries by (relay, since-bucket) into
+            // a handful of per-relay multi-author REQs. Goes from N-author
+            // * M-relay = N*M REQs (which blows browser WS caps and trips
+            // relay "too many concurrent REQs" NOTICEs) down to R*B REQs
+            // where R is the number of distinct relays targeted and B the
+            // number of since-buckets — usually R*B < 50 even for 500
+            // follows.
+            type Batch = {
+              relay: string
+              since: number | undefined // actual since we send
+              authors: string[] // full author list in this batch
+              filterTemplate: Filter // kinds, limit, plus any extra filter fields from the subRequest
+            }
+            const batchMap = new Map<string, Batch>()
+            const bucketSince = (since: number | undefined) =>
+              since === undefined
+                ? undefined
+                : Math.floor(since / SINCE_BUCKET_SECONDS) * SINCE_BUCKET_SECONDS
+
+            for (const q of freshAuthorQ) {
+              if (!q.pubkey) continue
+              const since = q.filter.since as number | undefined
+              const bucket = bucketSince(since)
+              // Strip single-author bits from the filter; we'll add authors
+              // per batch. Keep kinds / limit / any extra fields.
+              const { authors: _a, since: _s, ...rest } = q.filter
+              for (const relay of q.urls) {
+                const key = `${relay}|${bucket ?? 'none'}|${JSON.stringify(rest)}`
+                let batch = batchMap.get(key)
+                if (!batch) {
+                  batch = {
+                    relay,
+                    since: bucket,
+                    authors: [],
+                    filterTemplate: rest
+                  }
+                  batchMap.set(key, batch)
+                }
+                if (!batch.authors.includes(q.pubkey)) {
+                  batch.authors.push(q.pubkey)
+                }
+              }
+            }
+
+            // Split any batch whose author list exceeds AUTHORS_PER_BATCHED_REQ
+            // so relays don't reject oversize filters.
+            type FinalBatch = Batch & { id: string }
+            const finalBatches: FinalBatch[] = []
+            for (const batch of batchMap.values()) {
+              // Prioritize Special Follows inside each batch so they get
+              // into the first chunk when splits happen.
+              const sorted = [...batch.authors].sort((a, b) => {
+                const aP = pinnedPubkeySet.has(a) ? 1 : 0
+                const bP = pinnedPubkeySet.has(b) ? 1 : 0
+                return bP - aP
+              })
+              for (let i = 0; i < sorted.length; i += AUTHORS_PER_BATCHED_REQ) {
+                const slice = sorted.slice(i, i + AUTHORS_PER_BATCHED_REQ)
+                finalBatches.push({
+                  ...batch,
+                  authors: slice,
+                  id: `${batch.relay}|${batch.since ?? 'none'}|${i}`
+                })
+              }
+            }
+
+            // Observability: count how many queries actually failed so we
+            // can tell the user when things broke vs just returned empty.
+            let failedCount = 0
+            let okCount = 0
+
+            // Unified task queue: grouped fresh + batched fresh-author +
+            // per-author partial. All run through the same bounded pool
+            // so total concurrent REQs stay under BACKFILL_CONCURRENCY.
+            type Task = () => Promise<void>
+            const checkedAt = Math.floor(Date.now() / 1000)
+            const metaUpdates: {
+              pubkey: string
+              lastCheckedAt: number
+              lastCheckOk: boolean
+            }[] = []
+
+            const tasks: Task[] = []
+
+            // SUCCESS semantics (critical invariant — the cache is never
+            // thrown away): on resolve, update cache + bump meta. On throw,
+            // leave everything alone and let the next round/session retry.
+
+            // Grouped fresh queries (few, large).
+            for (const q of freshQ) {
+              tasks.push(async () => {
+                try {
+                  const evts = await client.fetchEvents(q.urls, q.filter)
+                  okCount++
+                  commitEvents(evts)
+                } catch {
+                  failedCount++
+                }
+              })
+            }
+
+            // Batched fresh-author queries (per-relay, multi-author).
+            for (const batch of finalBatches) {
+              tasks.push(async () => {
+                const filter: Filter = {
+                  ...batch.filterTemplate,
+                  authors: batch.authors
+                }
+                if (batch.since !== undefined) filter.since = batch.since
+                try {
+                  const evts = await client.fetchEvents([batch.relay], filter)
+                  okCount++
+                  commitEvents(evts)
+                  // Mark ALL authors in the batch as successfully checked
+                  // on this relay. (We don't track per-author-per-relay;
+                  // once any relay responds for an author, they're "seen".)
+                  if (evts.length > 0) {
+                    const items = evts.map((evt) => ({
+                      event: evt,
+                      relays: client.getEventHints(evt.id)
+                    }))
+                    indexedDb
+                      .putPulseEvents(items, PULSE_EVENTS_PER_USER_CAP)
+                      .catch(() => {})
+                  }
+                  for (const pubkey of batch.authors) {
+                    sinceByAuthorRef.current.set(pubkey, checkedAt)
+                    metaUpdates.push({
+                      pubkey,
+                      lastCheckedAt: checkedAt,
+                      lastCheckOk: true
+                    })
+                    freshTriedRef.current.add(pubkey)
+                  }
+                } catch {
+                  failedCount++
+                  // Leave cache + meta alone — next round retries.
+                }
+              })
+            }
+
+            // Per-author partial queries (author-specific `until`).
+            for (const q of partialQ) {
+              tasks.push(async () => {
+                try {
+                  const evts = await client.fetchEvents(q.urls, q.filter)
+                  okCount++
+                  commitEvents(evts)
+                  if (q.pubkey) {
+                    if (evts.length > 0) {
+                      const items = evts.map((evt) => ({
+                        event: evt,
+                        relays: client.getEventHints(evt.id)
+                      }))
+                      indexedDb
+                        .putPulseEvents(items, PULSE_EVENTS_PER_USER_CAP)
+                        .catch(() => {})
+                    }
+                    sinceByAuthorRef.current.set(q.pubkey, checkedAt)
+                    metaUpdates.push({
+                      pubkey: q.pubkey,
+                      lastCheckedAt: checkedAt,
+                      lastCheckOk: true
+                    })
+                    const floor = (q.filter.until as number) ?? 0
+                    const prev = backfillFloorRef.current.get(q.pubkey)
+                    if (prev === undefined || floor < prev) {
+                      backfillFloorRef.current.set(q.pubkey, floor)
+                    }
+                  }
+                } catch {
+                  failedCount++
+                }
+              })
+            }
+
+            // Bounded concurrency pool — keep concurrent REQs in flight
+            // below both the browser's WS cap and typical relay REQ caps.
+            let cursor = 0
+            const runNext = async (): Promise<void> => {
+              while (cursor < tasks.length) {
+                const i = cursor++
+                await tasks[i]()
+              }
+            }
+            const workers: Promise<void>[] = []
+            const poolSize = Math.min(BACKFILL_CONCURRENCY, tasks.length)
+            for (let i = 0; i < poolSize; i++) workers.push(runNext())
+
+            await Promise.allSettled(workers)
+
+            // Durably persist the meta bumps for authors that were
+            // successfully checked this round, so the next session knows
+            // where to resume.
+            if (metaUpdates.length > 0) {
+              indexedDb.putPulseAuthorMeta(metaUpdates).catch(() => {
+                // IDB errors are non-fatal.
+              })
+            }
+
+            // Warn in console when a significant fraction of queries blew
+            // up — usually it's the browser's WebSocket connection cap or
+            // downed relays. Cheap observability, no toast spam.
+            const totalQ = okCount + failedCount
+            if (totalQ > 0 && failedCount / totalQ > 0.25) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `[Pulse] backfill round: ${failedCount}/${totalQ} queries failed. ` +
+                  'Browser WebSocket limit or relay outages are likely; ' +
+                  'falling back to cache where available.'
+              )
+            }
+
+            if (fetchedTotal === 0) break
+            totalFetched += fetchedTotal
+          }
+
+          // Push the 'since' hint to the oldest event we now have.
+          if (accumulated.length > 0) {
+            const oldest = accumulated[accumulated.length - 1].created_at
+            setSince((prev) => (oldest < prev ? oldest : prev))
+          }
+
+          if (totalFetched === 0) {
+            setBackfillExhausted(true)
+          }
+          // NOTE: Events are now persisted per-author inside the worker on
+          // successful checks; no bulk flush here. This keeps the cache
+          // authoritative and ensures a timeout never wipes a user's cached
+          // events.
+        } finally {
+          setBackfilling(false)
+          userAggregationService.setBackfilling(feedId, false)
+        }
+      },
+      [subRequests, showKinds, feedId]
+    )
+
+    useEffect(() => {
+      if (!subRequests.length || !active) return
+
+      async function init() {
+        setLoading(true)
+        userAggregationService.setBackfilling(feedId, true)
+
+        if (showKinds?.length === 0 && subRequests.every(({ filter }) => !filter.kinds)) {
+          setLoading(false)
+          userAggregationService.setBackfilling(feedId, false)
+          return () => {}
+        }
+
+        const since = sinceRef.current
+
+        if (isPubkeyFeed) {
+          const storedEvents = await client.getEventsFromIndexed({
+            authors: subRequests.flatMap(({ filter }) => filter.authors ?? []),
+            kinds: showKinds ?? [],
+            since: dayjs().subtract(1, 'day').unix()
+          })
+          setStoredEvents(storedEvents)
+        }
+
+        const preprocessedSubRequests = await Promise.all(
+          subRequests.map(async ({ urls, filter }) => {
+            const relays = urls.length ? urls : await client.determineRelaysByFilter(filter)
+            return {
+              urls: relays,
+              filter: {
+                kinds: showKinds ?? [],
+                ...filter,
+                limit: LIMIT
+              }
+            }
+          })
+        )
+
+        const { closer } = await client.subscribeTimeline(
+          preprocessedSubRequests,
+          {
+            onEvents: (events, eosed) => {
+              if (events.length > 0) {
+                if (!since) {
+                  // Merge with whatever the IDB hydrator has put there,
+                  // instead of overwriting it. `events` is already sorted
+                  // desc by client.subscribeTimeline.
+                  setEvents((prev) => mergeTimelines([events, prev]))
+                } else {
+                  const newEvents = events.filter((evt) => evt.created_at >= since)
+                  setNewEvents((oldEvents) => mergeTimelines([newEvents, oldEvents]))
+                }
+              }
+              if (eosed) {
+                setLoading(false)
+                threadService.addRepliesToThread(events)
+
+                // Persist the initial grouped batch to the Pulse cache so
+                // events found here survive across sessions. We do NOT bump
+                // per-author meta from the grouped query — only per-author
+                // checks can confidently assert "this author was checked at
+                // time T" (the grouped query might have skipped an author
+                // whose posts live on non-feed relays).
+                if (events.length > 0) {
+                  const items = events.map((evt) => ({
+                    event: evt,
+                    relays: client.getEventHints(evt.id)
+                  }))
+                  indexedDb
+                    .putPulseEvents(items, PULSE_EVENTS_PER_USER_CAP)
+                    .catch(() => {})
+                }
+
+                // After the initial batch lands, top each author up toward
+                // PULSE_EVENTS_PER_USER_CAP. Algo relays skip this because
+                // their event set isn't a per-author timeline.
+                if (!areAlgoRelays) {
+                  const hasAuthors = subRequests.some(
+                    ({ filter }) => (filter.authors?.length ?? 0) > 0
+                  )
+                  if (hasAuthors) {
+                    runBackfill(events)
+                  } else {
+                    userAggregationService.setBackfilling(feedId, false)
+                  }
+                } else {
+                  userAggregationService.setBackfilling(feedId, false)
+                }
+              }
+            },
+            onNew: (event) => {
+              setNewEvents((oldEvents) => mergeTimelines([[event], oldEvents]))
+              threadService.addRepliesToThread([event])
+              // Stream new events into the Pulse cache too so a subsequent
+              // session shows them from cache instantly.
+              indexedDb
+                .putPulseEvents(
+                  [{ event, relays: client.getEventHints(event.id) }],
+                  PULSE_EVENTS_PER_USER_CAP
+                )
+                .catch(() => {})
+            },
+            onClose: (url, reason) => {
+              if (!showRelayCloseReason) return
+              // ignore reasons from nostr-tools
+              if (
+                [
+                  'closed by caller',
+                  'relay connection errored',
+                  'relay connection closed',
+                  'pingpong timed out',
+                  'relay connection closed by us'
+                ].includes(reason)
+              ) {
+                return
+              }
+
+              toast.error(`${url}: ${reason}`)
+            }
+          },
+          {
+            startLogin,
+            needSort: !areAlgoRelays,
+            needSaveToDb: isPubkeyFeed
+          }
+        )
+
+        return closer
+      }
+
+      const promise = init()
+      return () => {
+        promise.then((closer) => closer())
+      }
+    }, [feedId, refreshCount, active])
+
+    // "Load earlier" handler: we no longer reactively re-fetch as `since`
+    // changes (that was a no-op here because we removed the time filter).
+    // Instead, extending the timeline is triggered explicitly from the
+    // button click handler below.
+
+    useEffect(() => {
+      if (loading) {
+        setShowLoadingBar(true)
+        return
+      }
+
+      const timeout = setTimeout(() => {
+        setShowLoadingBar(false)
+      }, 1000)
+
+      return () => clearTimeout(timeout)
+    }, [loading])
+
+    const filterEvents = useCallback(
+      async (events: Event[]) => {
+        const results = await Promise.allSettled(
+          events.map(async (evt) => {
+            if (evt.pubkey === currentPubkey) return null
+            // NOTE: we deliberately do NOT filter by `since` here.
+            // Pulse shows up to N most recent events per user, unbounded
+            // by time. `since` is only a UI hint for the header label.
+            if (isEventDeleted(evt)) return null
+            if (filterMutedNotes && mutePubkeySet.has(evt.pubkey)) return null
+            if (
+              filterMutedNotes &&
+              hideContentMentioningMutedUsers &&
+              isMentioningMutedUsers(evt, mutePubkeySet)
+            ) {
+              return null
+            }
+            if (
+              trustScoreThreshold &&
+              !(await meetsMinTrustScore(evt.pubkey, trustScoreThreshold))
+            ) {
+              return null
+            }
+
+            return evt
+          })
+        )
+        return results
+          .filter((res) => res.status === 'fulfilled' && res.value !== null)
+          .map((res) => (res as PromiseFulfilledResult<Event>).value)
+      },
+      [
+        mutePubkeySet,
+        isEventDeleted,
+        currentPubkey,
+        filterMutedNotes,
+        hideContentMentioningMutedUsers,
+        isMentioningMutedUsers,
+        meetsMinTrustScore,
+        trustScoreThreshold
+      ]
+    )
+
+    // Derive the label from the oldest event actually loaded (not the
+    // `since` state, which is just a floor hint).
+    const oldestLoadedTs = useMemo(() => {
+      if (events.length === 0) return since
+      return events[events.length - 1].created_at
+    }, [events, since])
+
+    const lastXDays = useMemo(() => {
+      return Math.max(0, dayjs().diff(dayjs.unix(oldestLoadedTs), 'day'))
+    }, [oldestLoadedTs])
+
+    useEffect(() => {
+      const mergedEvents = mergeTimelines([events, storedEvents])
+      filterEvents(mergedEvents).then((filtered) => {
+        setFilteredEvents(filtered)
+      })
+    }, [events, storedEvents, filterEvents])
+
+    useEffect(() => {
+      filterEvents(newEvents).then((filtered) => {
+        setFilteredNewEvents(filtered)
+      })
+    }, [newEvents, filterEvents])
+
+    const allAuthors = useMemo(() => {
+      // Exclude the current user so the Pulse list and the filterEvents()
+      // pass agree: we already skip the user's own events in filterEvents,
+      // so keeping them in the padded follow list would show them forever
+      // as a zero-event "No posts found" row.
+      const set = new Set(subRequests.flatMap(({ filter }) => filter.authors ?? []))
+      if (currentPubkey) set.delete(currentPubkey)
+      return set
+    }, [JSON.stringify(subRequests), currentPubkey])
+
+    const fullAggregations = useMemo(() => {
+      const aggs = userAggregationService.aggregateByUser(filteredEvents)
+      // Pad with zero-event follows so every follow is visible. This lets
+      // the user spot inactive / no-profile follows they might want to prune.
+      const existing = new Set(aggs.map((a) => a.pubkey))
+      for (const pubkey of allAuthors) {
+        if (existing.has(pubkey)) continue
+        aggs.push({
+          pubkey,
+          events: [],
+          count: 0,
+          lastEventTime: 0
+        })
+      }
+      return aggs
+    }, [filteredEvents, allAuthors])
+
+    // Persist aggregations in an effect, not inside useMemo. saveAggregations
+    // synchronously notifies subscribers (UserAggregationDetailPage), which
+    // would then setState during DeepPulseList's render and trigger the
+    // React warning: "Cannot update a component while rendering a different
+    // component". Running it in useEffect defers the notify to after commit.
+    useEffect(() => {
+      userAggregationService.saveAggregations(feedId, fullAggregations)
+    }, [feedId, fullAggregations])
+
+    const aggregations = useMemo(() => {
+      // Cap each user's events to the most-recent N for the list view.
+      // The detail page reads the full uncapped set from the service.
+      return fullAggregations.map((agg) => {
+        const sorted = [...agg.events].sort((a, b) => b.created_at - a.created_at)
+        const top = sorted.slice(0, PULSE_EVENTS_PER_USER_CAP)
+        return {
+          ...agg,
+          events: top,
+          count: top.length,
+          lastEventTime: top.length > 0 ? top[0].created_at : agg.lastEventTime
+        }
+      })
+    }, [fullAggregations])
+
+    const pinnedAggregations = useMemo(() => {
+      return aggregations.filter((agg) => pinnedPubkeySet.has(agg.pubkey))
+    }, [aggregations, pinnedPubkeySet])
+
+    const normalAggregations = useMemo(() => {
+      return aggregations.filter((agg) => !pinnedPubkeySet.has(agg.pubkey))
+    }, [aggregations, pinnedPubkeySet])
+
+    const displayedNormalAggregations = useMemo(() => {
+      return normalAggregations.slice(0, showCount)
+    }, [normalAggregations, showCount])
+
+    const hasMoreToDisplay = useMemo(() => {
+      return normalAggregations.length > displayedNormalAggregations.length
+    }, [normalAggregations, displayedNormalAggregations])
+
+    useEffect(() => {
+      const options = {
+        root: null,
+        rootMargin: '600px',
+        threshold: 0
+      }
+      const observerInstance = new IntersectionObserver((entries) => {
+        if (!entries[0].isIntersecting) return
+        if (hasMoreToDisplay) {
+          // Reveal more already-aggregated users first (cheap).
+          setShowCount((count) => count + SHOW_COUNT)
+        } else if (!loading && !backfilling && !backfillExhausted) {
+          // We've shown everyone we have; try to find more events
+          // further back for the users who aren't fully topped up.
+          runBackfill(events, true)
+        }
+      }, options)
+
+      const currentBottomRef = bottomRef.current
+      if (currentBottomRef) {
+        observerInstance.observe(currentBottomRef)
+      }
+
+      return () => {
+        if (observerInstance && currentBottomRef) {
+          observerInstance.unobserve(currentBottomRef)
+        }
+      }
+    }, [hasMoreToDisplay, loading, backfilling, backfillExhausted, events, runBackfill])
+
+    const handleViewUser = (agg: TUserAggregation) => {
+      // Mark as viewed when user clicks
+      userAggregationService.markAsViewed(feedId, agg.pubkey)
+      setNewEventPubkeys((prev) => {
+        const newSet = new Set(prev)
+        newSet.delete(agg.pubkey)
+        return newSet
+      })
+
+      if (agg.count === 1) {
+        const evt = agg.events[0]
+        if (evt.kind !== kinds.Repost && evt.kind !== kinds.GenericRepost) {
+          push(toNote(agg.events[0]))
+          return
+        }
+      }
+
+      push(toUserAggregationDetail(feedId, agg.pubkey))
+    }
+
+    const handleLoadEarlier = () => {
+      setShowCount(SHOW_COUNT)
+      // Run another backfill pass. `deeper=true` re-queries authors whose
+      // floor we've already hit, pushing further into the past.
+      runBackfill(events, true)
+    }
+
+    const showNewEvents = () => {
+      const pubkeySet = new Set<string>()
+      let hasPinnedUser = false
+      newEvents.forEach((evt) => {
+        pubkeySet.add(evt.pubkey)
+        if (pinnedPubkeySet.has(evt.pubkey)) {
+          hasPinnedUser = true
+        }
+      })
+      setNewEventPubkeys(pubkeySet)
+      setEvents((oldEvents) => [...newEvents, ...oldEvents])
+      setNewEvents([])
+      setTimeout(() => {
+        if (hasPinnedUser) {
+          scrollToTop('smooth')
+          return
+        }
+        nonPinnedTopRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }, 0)
+    }
+
+    const list = (
+      <div className="min-h-screen">
+        {pinnedAggregations.map((agg) => (
+          <UserAggregationItem
+            key={agg.pubkey}
+            feedId={feedId}
+            aggregation={agg}
+            onClick={() => handleViewUser(agg)}
+            isNew={newEventPubkeys.has(agg.pubkey)}
+          />
+        ))}
+
+        <div ref={nonPinnedTopRef} className="scroll-mt-[calc(6rem+1px)]" />
+        {normalAggregations.map((agg) => (
+          <UserAggregationItem
+            key={agg.pubkey}
+            feedId={feedId}
+            aggregation={agg}
+            onClick={() => handleViewUser(agg)}
+            isNew={newEventPubkeys.has(agg.pubkey)}
+          />
+        ))}
+
+        {loading || backfilling || hasMoreToDisplay || !backfillExhausted ? (
+          <div ref={bottomRef}>
+            <UserAggregationItemSkeleton />
+          </div>
+        ) : aggregations.length === 0 ? (
+          <div className="mt-2 flex w-full justify-center">
+            <Button size="lg" onClick={() => setRefreshCount((count) => count + 1)}>
+              {t('Reload')}
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-2 text-center text-sm text-muted-foreground">{t('no more notes')}</div>
+        )}
+      </div>
+    )
+
+    return (
+      <div>
+        <div ref={topRef} className="scroll-mt-[calc(6rem+1px)]" />
+        {showLoadingBar && <LoadingBar />}
+        <div className="flex h-12 items-center justify-between gap-2 border-b pl-4 pr-1">
+          <div className="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {lastXDays === 1
+                ? t('Last 24 hours')
+                : t('Last {{count}} days', { count: lastXDays })}
+            </span>
+            ·
+            <span>
+              {filteredEvents.length} {t('notes')}
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            className="h-10 shrink-0 rounded-lg px-3 text-muted-foreground hover:text-foreground"
+            disabled={loading || backfilling}
+            onClick={handleLoadEarlier}
+          >
+            {loading || backfilling ? (
+              <Loader className="animate-spin" />
+            ) : (
+              <History />
+            )}
+            {t('Load earlier')}
+          </Button>
+        </div>
+        {supportTouch ? (
+          <PullToRefresh
+            onRefresh={async () => {
+              refresh()
+              await new Promise((resolve) => setTimeout(resolve, 1000))
+            }}
+          >
+            {list}
+          </PullToRefresh>
+        ) : (
+          list
+        )}
+        <div className="h-20" />
+        {filteredNewEvents.length > 0 && (
+          <NewNotesButton newEvents={filteredNewEvents} onClick={showNewEvents} />
+        )}
+      </div>
+    )
+  }
+)
+DeepPulseList.displayName = 'DeepPulseList'
+export default DeepPulseList
+
+function UserAggregationItem({
+  feedId,
+  aggregation,
+  onClick,
+  isNew
+}: {
+  feedId: string
+  aggregation: TUserAggregation
+  onClick: () => void
+  isNew?: boolean
+}) {
+  const { t } = useTranslation()
+  const supportTouch = useMemo(() => isTouchDevice(), [])
+  const [hasNewEvents, setHasNewEvents] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [feedBackfilling, setFeedBackfilling] = useState(false)
+  const { isPinned, togglePin } = usePinnedUsers()
+  const pinned = useMemo(() => isPinned(aggregation.pubkey), [aggregation.pubkey, isPinned])
+
+  useEffect(() => {
+    const update = () => {
+      const lastViewedTime = userAggregationService.getLastViewedTime(feedId, aggregation.pubkey)
+      setHasNewEvents(aggregation.lastEventTime > lastViewedTime)
+    }
+
+    const unSub = userAggregationService.subscribeViewedTimeChange(
+      feedId,
+      aggregation.pubkey,
+      () => {
+        update()
+      }
+    )
+
+    update()
+
+    return unSub
+  }, [feedId, aggregation])
+
+  useEffect(() => {
+    const update = () => {
+      setFeedBackfilling(userAggregationService.isBackfilling(feedId))
+    }
+    const unSub = userAggregationService.subscribeBackfillChange(feedId, update)
+    update()
+    return unSub
+  }, [feedId])
+
+  const onTogglePin = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setLoading(true)
+    togglePin(aggregation.pubkey).finally(() => {
+      setLoading(false)
+    })
+  }
+
+  const onToggleViewed = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (hasNewEvents) {
+      userAggregationService.markAsViewed(feedId, aggregation.pubkey)
+    } else {
+      userAggregationService.markAsUnviewed(feedId, aggregation.pubkey)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'group relative flex cursor-pointer items-center gap-4 border-b px-4 py-3 transition-all duration-200 hover:bg-accent/30',
+        isNew && 'bg-primary/15 hover:bg-primary/20'
+      )}
+      onClick={onClick}
+    >
+      {supportTouch ? (
+        <SimpleUserAvatar
+          userId={aggregation.pubkey}
+          className={!hasNewEvents ? 'grayscale' : ''}
+        />
+      ) : (
+        <UserAvatar userId={aggregation.pubkey} className={!hasNewEvents ? 'grayscale' : ''} />
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center gap-2">
+          {supportTouch ? (
+            <SimpleUsername
+              userId={aggregation.pubkey}
+              className={cn(
+                'max-w-fit truncate text-base font-semibold',
+                !hasNewEvents && 'text-muted-foreground'
+              )}
+              skeletonClassName="h-4"
+            />
+          ) : (
+            <Username
+              userId={aggregation.pubkey}
+              className={cn(
+                'max-w-fit truncate text-base font-semibold',
+                !hasNewEvents && 'text-muted-foreground'
+              )}
+              skeletonClassName="h-4"
+            />
+          )}
+          <TrustScoreBadge pubkey={aggregation.pubkey} />
+        </div>
+        {aggregation.lastEventTime > 0 ? (
+          <FormattedTimestamp
+            timestamp={aggregation.lastEventTime}
+            className="text-sm text-muted-foreground"
+          />
+        ) : feedBackfilling ? (
+          <span className="text-sm text-muted-foreground italic">{t('Checking...')}</span>
+        ) : (
+          <span className="text-sm text-muted-foreground">{t('No posts found')}</span>
+        )}
+      </div>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onTogglePin}
+        className={`shrink-0 ${
+          pinned
+            ? 'text-primary hover:text-primary/80'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+        title={pinned ? t('Unfollow Special') : t('Special Follow')}
+      >
+        {loading ? (
+          <Loader className="animate-spin" />
+        ) : (
+          <Star className={pinned ? 'fill-primary stroke-primary' : ''} />
+        )}
+      </Button>
+
+      {/*
+        New-events indicator. The count is deliberately not shown because
+        per-user events are capped at PULSE_EVENTS_PER_USER_CAP for display,
+        so it would always read 0 or the cap — no signal. A filled dot means
+        "new activity since last viewed"; click to mark viewed/unviewed.
+      */}
+      {aggregation.count > 0 && (
+        <button
+          className={cn(
+            'flex size-6 shrink-0 items-center justify-center rounded-full transition-colors',
+            hasNewEvents
+              ? 'bg-primary hover:bg-primary/80'
+              : 'bg-muted-foreground/30 hover:bg-muted-foreground/50'
+          )}
+          onClick={onToggleViewed}
+          title={hasNewEvents ? t('Mark as viewed') : t('Mark as unviewed')}
+          aria-label={hasNewEvents ? t('Mark as viewed') : t('Mark as unviewed')}
+        />
+      )}
+    </div>
+  )
+}
+
+function UserAggregationItemSkeleton() {
+  return (
+    <div className="flex items-center gap-4 px-4 py-3">
+      <UserAvatarSkeleton className="size-10" />
+      <div className="flex-1">
+        <Skeleton className="my-1 h-4 w-36" />
+        <Skeleton className="my-1 h-3 w-14" />
+      </div>
+      <UserAvatarSkeleton className="size-10" />
+    </div>
+  )
+}

--- a/src/components/KindFilter/index.tsx
+++ b/src/components/KindFilter/index.tsx
@@ -28,7 +28,10 @@ export const KIND_FILTER_OPTIONS = [
       ExtendedKind.ADDRESSABLE_SHORT_VIDEO
     ],
     label: 'Video Posts'
-  }
+  },
+  // Off by default (not part of ALLOWED_FILTER_KINDS) — opt-in for users who
+  // want reactions in the timeline / Pulse aggregation.
+  { kindGroup: [kinds.Reaction, ExtendedKind.EXTERNAL_CONTENT_REACTION], label: 'Reactions' }
 ]
 const ALL_KINDS = KIND_FILTER_OPTIONS.flatMap(({ kindGroup }) => kindGroup)
 

--- a/src/components/NormalFeed/index.tsx
+++ b/src/components/NormalFeed/index.tsx
@@ -1,3 +1,4 @@
+import DeepPulseList, { TDeepPulseListRef } from '@/components/DeepPulseList'
 import FeedTabsCustomizeDialog from '@/components/FeedTabsCustomizeDialog'
 import NoteList, { TNoteListRef } from '@/components/NoteList'
 import Tabs from '@/components/Tabs'
@@ -36,8 +37,16 @@ export default function NormalFeed({
   const feedShowKinds = useMemo(() => getShowKinds(feedId), [getShowKinds, feedId])
   const [temporaryShowKinds, setTemporaryShowKinds] = useState(feedShowKinds)
 
+  // `disable24hMode` is used by hashtag/search secondary feeds where there
+  // are no stable authors, so per-author aggregation (24h Pulse + deep Pulse)
+  // doesn't make sense. We treat both aggregation builtins the same here.
   const visibleTabs = useMemo(
-    () => feedTabs.filter((tab) => !tab.hidden && !(tab.builtin === '24h' && disable24hMode)),
+    () =>
+      feedTabs.filter(
+        (tab) =>
+          !tab.hidden &&
+          !(disable24hMode && (tab.builtin === '24h' || tab.builtin === 'pulse'))
+      ),
     [feedTabs, disable24hMode]
   )
 
@@ -55,6 +64,7 @@ export default function NormalFeed({
   const supportTouch = useMemo(() => isTouchDevice(), [])
   const noteListRef = useRef<TNoteListRef>(null)
   const userAggregationListRef = useRef<TUserAggregationListRef>(null)
+  const deepPulseListRef = useRef<TDeepPulseListRef>(null)
   const topRef = useRef<HTMLDivElement>(null)
   const subRequestsHaveKinds = useMemo(() => {
     return subRequests.some((req) => !!req.filter.kinds?.length)
@@ -69,6 +79,7 @@ export default function NormalFeed({
 
   const tabHasFixedKinds = !!selectedTab?.kinds
   const is24hMode = selectedTab?.builtin === '24h'
+  const isPulseMode = selectedTab?.builtin === 'pulse'
   const effectiveShowKinds = selectedTab?.kinds ?? temporaryShowKinds
   const hideReplies = selectedTab?.hideReplies ?? false
 
@@ -108,6 +119,8 @@ export default function NormalFeed({
                   }
                   if (is24hMode) {
                     userAggregationListRef.current?.refresh()
+                  } else if (isPulseMode) {
+                    deepPulseListRef.current?.refresh()
                   } else {
                     noteListRef.current?.refresh()
                   }
@@ -133,6 +146,16 @@ export default function NormalFeed({
         is24hMode ? (
           <UserAggregationList
             ref={userAggregationListRef}
+            showKinds={effectiveShowKinds}
+            subRequests={subRequests}
+            areAlgoRelays={areAlgoRelays}
+            showRelayCloseReason={showRelayCloseReason}
+            isPubkeyFeed={isPubkeyFeed}
+            trustScoreThreshold={trustScoreThreshold}
+          />
+        ) : isPulseMode ? (
+          <DeepPulseList
+            ref={deepPulseListRef}
             showKinds={effectiveShowKinds}
             subRequests={subRequests}
             areAlgoRelays={areAlgoRelays}

--- a/src/components/Profile/ProfileFeed.tsx
+++ b/src/components/Profile/ProfileFeed.tsx
@@ -27,7 +27,11 @@ export default function ProfileFeed({ pubkey, search = '' }: { pubkey: string; s
   const [temporaryShowKinds, setTemporaryShowKinds] = useState(feedShowKinds)
 
   const visibleTabs = useMemo(() => {
-    const base = feedTabs.filter((tab) => !tab.hidden && tab.builtin !== '24h')
+    // Per-author aggregation tabs (24h Pulse, deep Pulse) don't make sense
+    // on a single profile page — we're already scoped to one author.
+    const base = feedTabs.filter(
+      (tab) => !tab.hidden && tab.builtin !== '24h' && tab.builtin !== 'pulse'
+    )
     if (myPubkey && myPubkey !== pubkey) {
       return [...base, YOU_TAB]
     }

--- a/src/components/UserAggregationList/pulse-backfill.spec.ts
+++ b/src/components/UserAggregationList/pulse-backfill.spec.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest'
+import { Event } from 'nostr-tools'
+import { planBackfillRound } from './pulse-backfill'
+
+// Helpers
+let nextId = 1
+const mkEvent = (pubkey: string, ts: number): Event => ({
+  id: String(nextId++).padStart(64, '0'),
+  pubkey,
+  created_at: ts,
+  kind: 1,
+  tags: [],
+  content: '',
+  sig: ''
+})
+
+const baseInput = (overrides: Partial<Parameters<typeof planBackfillRound>[0]> = {}) => ({
+  subRequests: [
+    {
+      urls: ['wss://relay.example/'],
+      filter: { authors: ['A', 'B', 'C'], kinds: [1] }
+    }
+  ],
+  showKinds: [1],
+  accumulated: [] as Event[],
+  perUserCap: 10,
+  floors: new Map<string, number>(),
+  deeper: false,
+  freshLimit: 1000,
+  partialLimit: 10,
+  ...overrides
+})
+
+describe('planBackfillRound', () => {
+  it('returns no queries when every author already has >= cap events', () => {
+    const accumulated: Event[] = []
+    for (let i = 0; i < 10; i++) accumulated.push(mkEvent('A', 2_000_000 - i))
+    for (let i = 0; i < 10; i++) accumulated.push(mkEvent('B', 2_000_000 - i))
+    for (let i = 0; i < 10; i++) accumulated.push(mkEvent('C', 2_000_000 - i))
+
+    const out = planBackfillRound(baseInput({ accumulated }))
+    expect(out.queries).toEqual([])
+    expect(out.needy).toEqual([])
+  })
+
+  it('emits a grouped fresh + a per-author fresh-author query for zero-event authors', () => {
+    const out = planBackfillRound(baseInput({ accumulated: [] }))
+    expect(out.freshAuthors.sort()).toEqual(['A', 'B', 'C'])
+    expect(out.partialAuthors).toEqual([])
+
+    // Grouped catch-all on feed relays.
+    const fresh = out.queries.filter((q) => q.kind === 'fresh')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0].filter.authors).toEqual(['A', 'B', 'C'])
+    expect(fresh[0].filter.until).toBeUndefined()
+    expect(fresh[0].filter.limit).toBe(1000)
+
+    // Per-author queries meant to run on each author's write relays
+    // (caller merges those in). One per fresh author.
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    expect(freshAuthor.map((q) => q.pubkey).sort()).toEqual(['A', 'B', 'C'])
+    for (const q of freshAuthor) {
+      expect(q.filter.authors).toEqual([q.pubkey])
+      expect(q.filter.until).toBeUndefined()
+    }
+  })
+
+  it('skips grouped + per-author fresh queries for authors in freshTried', () => {
+    // After round 1: A and B have been tried on their write relays without
+    // finding anything; C hasn't been tried yet.
+    const out = planBackfillRound(
+      baseInput({
+        accumulated: [],
+        freshTried: new Set(['A', 'B'])
+      })
+    )
+    // Grouped fresh should only include still-untried authors.
+    const fresh = out.queries.filter((q) => q.kind === 'fresh')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0].filter.authors).toEqual(['C'])
+
+    // Per-author fresh likewise only for still-untried authors.
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    expect(freshAuthor.map((q) => q.pubkey)).toEqual(['C'])
+  })
+
+  it('re-emits per-author fresh queries for freshTried authors when deeper=true', () => {
+    const out = planBackfillRound(
+      baseInput({
+        accumulated: [],
+        freshTried: new Set(['A', 'B', 'C']),
+        deeper: true
+      })
+    )
+    // Grouped fresh is still skipped (freshTried wins for the grouped pass).
+    // But "Load earlier" should retry per-author even when we think we've
+    // exhausted their write relays — the user is explicitly asking.
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    expect(freshAuthor.map((q) => q.pubkey).sort()).toEqual(['A', 'B', 'C'])
+  })
+
+  it(
+    'uses per-author `until` for partial authors (regression: the "years of ' +
+      'discrepancy" bug came from sharing a global min until across authors)',
+    () => {
+      // A's oldest event is very old (2020-01-01). B's is recent (2025-01-01).
+      // If we (buggy) used a shared min until=A.oldest for BOTH, B's events
+      // between 2020 and 2025 would never be queried for.
+      const A_OLDEST = Math.floor(new Date('2020-01-01Z').getTime() / 1000)
+      const B_OLDEST = Math.floor(new Date('2025-01-01Z').getTime() / 1000)
+      const accumulated = [
+        mkEvent('A', A_OLDEST + 100),
+        mkEvent('A', A_OLDEST),
+        mkEvent('B', B_OLDEST + 100),
+        mkEvent('B', B_OLDEST)
+      ]
+      const out = planBackfillRound(
+        baseInput({
+          accumulated,
+          subRequests: [
+            {
+              urls: ['wss://r/'],
+              filter: { authors: ['A', 'B'], kinds: [1] }
+            }
+          ]
+        })
+      )
+
+      const partial = out.queries.filter((q) => q.kind === 'partial')
+      // One partial query per author with their OWN until.
+      expect(partial.map((q) => q.pubkey).sort()).toEqual(['A', 'B'])
+      const byAuthor = Object.fromEntries(partial.map((q) => [q.pubkey!, q]))
+      expect(byAuthor.A.filter.until).toBe(A_OLDEST - 1)
+      expect(byAuthor.B.filter.until).toBe(B_OLDEST - 1)
+      // Each partial query targets exactly one author, not a group.
+      expect(byAuthor.A.filter.authors).toEqual(['A'])
+      expect(byAuthor.B.filter.authors).toEqual(['B'])
+    }
+  )
+
+  it('mixes fresh and partial authors correctly in a single round', () => {
+    // A: has events. B: zero events (fresh). C: has events.
+    const accumulated = [mkEvent('A', 1000), mkEvent('C', 900)]
+    const out = planBackfillRound(baseInput({ accumulated }))
+
+    expect(out.freshAuthors).toEqual(['B'])
+    expect(out.partialAuthors.sort()).toEqual(['A', 'C'])
+
+    const fresh = out.queries.filter((q) => q.kind === 'fresh')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0].filter.authors).toEqual(['B'])
+    expect(fresh[0].filter.until).toBeUndefined()
+
+    // B also gets a per-author fresh query for her write relays.
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    expect(freshAuthor).toHaveLength(1)
+    expect(freshAuthor[0].pubkey).toBe('B')
+
+    const partial = out.queries.filter((q) => q.kind === 'partial')
+    expect(partial).toHaveLength(2)
+    const byPk = Object.fromEntries(partial.map((q) => [q.pubkey!, q]))
+    expect(byPk.A.filter.until).toBe(999)
+    expect(byPk.C.filter.until).toBe(899)
+  })
+
+  it('skips a partial author when their floor has already been reached', () => {
+    // A's oldest is 1000; we've previously queried back to 1000.
+    // Running the planner again without `deeper` should skip A.
+    const accumulated = [mkEvent('A', 1000)]
+    const out = planBackfillRound(
+      baseInput({
+        accumulated,
+        floors: new Map([['A', 1000]]),
+        subRequests: [
+          { urls: [], filter: { authors: ['A'], kinds: [1] } }
+        ]
+      })
+    )
+    expect(out.queries).toEqual([])
+  })
+
+  it('re-queries partial authors past their floor when deeper=true', () => {
+    const accumulated = [mkEvent('A', 1000)]
+    const out = planBackfillRound(
+      baseInput({
+        accumulated,
+        floors: new Map([['A', 1000]]),
+        deeper: true,
+        subRequests: [
+          { urls: [], filter: { authors: ['A'], kinds: [1] } }
+        ]
+      })
+    )
+    expect(out.queries).toHaveLength(1)
+    expect(out.queries[0].kind).toBe('partial')
+    expect(out.queries[0].filter.until).toBe(999)
+  })
+
+  it('uses sinceByAuthor to scope the per-author fresh query (gap-fill mode)', () => {
+    const LAST_OK = 1_700_000_000 // some previous successful check
+    const out = planBackfillRound(
+      baseInput({
+        accumulated: [],
+        sinceByAuthor: new Map([['A', LAST_OK]])
+      })
+    )
+    // A has a lastCheckedAt — their fresh-author query must be bounded to
+    // `since: LAST_OK` so we only fill the gap.
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    const byAuthor = Object.fromEntries(freshAuthor.map((q) => [q.pubkey!, q]))
+    expect(byAuthor.A.filter.since).toBe(LAST_OK)
+    // B and C were never checked — their queries stay unbounded.
+    expect(byAuthor.B.filter.since).toBeUndefined()
+    expect(byAuthor.C.filter.since).toBeUndefined()
+  })
+
+  it('deeper=true ignores sinceByAuthor (full historical refetch)', () => {
+    const LAST_OK = 1_700_000_000
+    const out = planBackfillRound(
+      baseInput({
+        accumulated: [],
+        sinceByAuthor: new Map([['A', LAST_OK]]),
+        deeper: true
+      })
+    )
+    const freshAuthor = out.queries.filter((q) => q.kind === 'fresh-author')
+    const a = freshAuthor.find((q) => q.pubkey === 'A')!
+    expect(a.filter.since).toBeUndefined()
+  })
+
+  it('respects subRequest grouping: only queries authors for groups that list them', () => {
+    const accumulated: Event[] = []
+    const out = planBackfillRound(
+      baseInput({
+        accumulated,
+        subRequests: [
+          { urls: ['wss://r1/'], filter: { authors: ['A', 'B'], kinds: [1] } },
+          { urls: ['wss://r2/'], filter: { authors: ['C'], kinds: [1] } }
+        ]
+      })
+    )
+    // All three authors fresh → one fresh query per subRequest group.
+    const fresh = out.queries.filter((q) => q.kind === 'fresh')
+    expect(fresh.map((q) => q.filter.authors).sort()).toEqual([['A', 'B'], ['C']])
+  })
+
+  it('preserves extra filter fields (e.g. kinds) in built queries', () => {
+    const accumulated: Event[] = [mkEvent('A', 1000)]
+    const out = planBackfillRound(
+      baseInput({
+        accumulated,
+        showKinds: [1, 6],
+        subRequests: [
+          {
+            urls: [],
+            filter: { authors: ['A'], kinds: [1, 6], '#t': ['bitcoin'] } as any
+          }
+        ]
+      })
+    )
+    const q = out.queries.find((x) => x.kind === 'partial')!
+    expect(q.filter.kinds).toEqual([1, 6])
+    expect((q.filter as any)['#t']).toEqual(['bitcoin'])
+  })
+
+  it('deduplicates authors that appear in multiple subRequest groups', () => {
+    // A is in both groups. Fresh queries should be emitted for each group
+    // (per-group relay set). Partial queries likewise.
+    const accumulated: Event[] = []
+    const out = planBackfillRound(
+      baseInput({
+        accumulated,
+        subRequests: [
+          { urls: ['wss://r1/'], filter: { authors: ['A'], kinds: [1] } },
+          { urls: ['wss://r2/'], filter: { authors: ['A'], kinds: [1] } }
+        ]
+      })
+    )
+    expect(out.freshAuthors).toEqual(['A'])
+    const fresh = out.queries.filter((q) => q.kind === 'fresh')
+    expect(fresh).toHaveLength(2) // one per group
+    expect(fresh.map((q) => q.urls[0]).sort()).toEqual([
+      'wss://r1/',
+      'wss://r2/'
+    ])
+  })
+})

--- a/src/components/UserAggregationList/pulse-backfill.ts
+++ b/src/components/UserAggregationList/pulse-backfill.ts
@@ -1,0 +1,219 @@
+// Pure helpers for the Pulse-tab per-author backfill planner.
+//
+// This file is deliberately kept framework-free so it can be unit-tested
+// without spinning up React or the Nostr client.
+//
+// Design intent:
+//   The Pulse feed aggregates events by author and shows up to N most
+//   recent events per author. The initial timeline subscription fetches
+//   a bounded number of recent events across ALL followees together;
+//   prolific authors saturate the limit and inactive authors may get
+//   zero or very few events back. The backfill planner's job is to
+//   top up each author to N events efficiently, without bugs.
+//
+// The important bug we're avoiding:
+//   Using a SHARED `until` across authors with different oldest
+//   timestamps silently drops events for authors whose oldest known
+//   event is more recent than the group minimum. E.g. author A's
+//   oldest=2020 and author B's oldest=2025 with shared until=2020
+//   means B's 2021-2024 events are never queried. Fix: one query per
+//   author with their own `until = oldest - 1`.
+import { Event, Filter } from 'nostr-tools'
+
+export type PulseSubRequest = {
+  urls: string[]
+  filter: Omit<Filter, 'since' | 'until'>
+}
+
+export type PlannedQuery = {
+  // Identifies the origin so callers can track per-author state.
+  //   'fresh'        : grouped catch-all on feed relays for authors with 0
+  //                    events — cheap first pass.
+  //   'fresh-author' : per-author catch-all intended to run on that author's
+  //                    write relays (caller merges them in). Needed because
+  //                    the grouped pass only hits the feed's relays, which
+  //                    may not overlap with the author's outbox.
+  //   'partial'      : per-author backfill for authors who already have some
+  //                    events but fewer than the cap.
+  kind: 'fresh' | 'fresh-author' | 'partial'
+  // Set for 'fresh-author' and 'partial' (single-author queries).
+  pubkey?: string
+  urls: string[]
+  filter: Filter
+}
+
+export type PlanInput = {
+  subRequests: PulseSubRequest[]
+  showKinds: number[]
+  // Events accumulated so far (from initial fetch + prior backfill rounds).
+  accumulated: Event[]
+  // Per-author target count.
+  perUserCap: number
+  // Previously-queried backfill floor per author. If we've already
+  // queried down to floor F and the author's oldest is still F, we
+  // know the relay has nothing older — skip unless `deeper` is set.
+  floors: Map<string, number>
+  // Authors we've already queried on their own write relays without finding
+  // anything. Skip re-issuing a per-author fresh query for these.
+  freshTried?: Set<string>
+  // Per-author timestamp of the last SUCCESSFUL check (EOSE received, no
+  // errors). When set, the per-author fresh query becomes a gap-fill with
+  // `since: lastCheckedAt` instead of an unbounded fetch. Authors not in
+  // this map are treated as never-checked and get an unbounded query.
+  sinceByAuthor?: Map<string, number>
+  // When true, re-query authors whose floor has already been reached.
+  // Used by the explicit "Load earlier" button.
+  deeper: boolean
+  // Limit for the fresh-author catch-all query.
+  freshLimit: number
+  // Limit for per-author partial queries.
+  partialLimit: number
+}
+
+export type PlanOutput = {
+  queries: PlannedQuery[]
+  needy: string[]
+  freshAuthors: string[]
+  partialAuthors: string[]
+}
+
+// Count events per author and track each author's oldest timestamp.
+function summarize(
+  allAuthors: string[],
+  accumulated: Event[]
+): {
+  count: Map<string, number>
+  oldestByAuthor: Map<string, number>
+} {
+  const count = new Map<string, number>()
+  const oldestByAuthor = new Map<string, number>()
+  const authorSet = new Set(allAuthors)
+  for (const a of allAuthors) count.set(a, 0)
+  for (const e of accumulated) {
+    if (!authorSet.has(e.pubkey)) continue
+    count.set(e.pubkey, (count.get(e.pubkey) ?? 0) + 1)
+    const prev = oldestByAuthor.get(e.pubkey)
+    if (prev === undefined || e.created_at < prev) {
+      oldestByAuthor.set(e.pubkey, e.created_at)
+    }
+  }
+  return { count, oldestByAuthor }
+}
+
+/**
+ * Plan the next round of backfill queries.
+ *
+ * Returns the queries to run plus the bookkeeping the caller needs
+ * (needy/fresh/partial lists are exposed primarily for test assertions).
+ */
+export function planBackfillRound(input: PlanInput): PlanOutput {
+  const { subRequests, showKinds, accumulated, perUserCap, floors, deeper } =
+    input
+
+  const allAuthors = Array.from(
+    new Set(subRequests.flatMap(({ filter }) => filter.authors ?? []))
+  )
+  if (allAuthors.length === 0) {
+    return { queries: [], needy: [], freshAuthors: [], partialAuthors: [] }
+  }
+
+  const { count, oldestByAuthor } = summarize(allAuthors, accumulated)
+
+  const needy = allAuthors.filter((a) => (count.get(a) ?? 0) < perUserCap)
+  if (needy.length === 0) {
+    return { queries: [], needy: [], freshAuthors: [], partialAuthors: [] }
+  }
+
+  const freshAuthors = needy.filter((a) => !oldestByAuthor.has(a))
+  const partialAuthors = needy.filter((a) => oldestByAuthor.has(a))
+
+  const queries: PlannedQuery[] = []
+  const freshTried = input.freshTried ?? new Set<string>()
+
+  // (1) Grouped catch-all on the feed's relays — cheap first pass that works
+  // whenever the feed's relays happen to hold the author's posts. Skip any
+  // authors who've already been through this pass without results (tracked
+  // via freshTried); they need a per-author try on their own write relays.
+  if (freshAuthors.length > 0) {
+    for (const { urls, filter } of subRequests) {
+      const inGroup = (filter.authors ?? []).filter(
+        (a) => freshAuthors.includes(a) && !freshTried.has(a)
+      )
+      if (inGroup.length === 0) continue
+      queries.push({
+        kind: 'fresh',
+        urls,
+        filter: {
+          kinds: showKinds,
+          ...filter,
+          authors: inGroup,
+          limit: input.freshLimit
+        }
+      })
+    }
+  }
+
+  // (2) Per-author catch-all intended for each fresh author's write relays.
+  // This is what catches authors whose posts live on relays the feed doesn't
+  // read from (classic "outbox" mismatch — the Lyn Alden case). The caller
+  // is responsible for merging in the author's NIP-65 write relays before
+  // firing these; the planner just marks them as 'fresh-author'.
+  //
+  // If we have a `sinceByAuthor` entry for an author, the query is a
+  // gap-fill since the last successful check: `since: lastCheckedAt`. That
+  // avoids re-fetching an author's whole timeline every session — the
+  // cache holds the older events and we only ask relays for what's new.
+  const sinceByAuthor = input.sinceByAuthor
+  for (const pubkey of freshAuthors) {
+    if (freshTried.has(pubkey) && !deeper) continue
+    const since = sinceByAuthor?.get(pubkey)
+    for (const { urls, filter } of subRequests) {
+      if (!(filter.authors ?? []).includes(pubkey)) continue
+      const perFilter: Filter = {
+        kinds: showKinds,
+        ...filter,
+        authors: [pubkey],
+        limit: input.partialLimit
+      }
+      // `deeper=true` means the user wants a full historical refetch,
+      // so ignore the since-hint in that mode.
+      if (since !== undefined && since > 0 && !deeper) {
+        perFilter.since = since
+      }
+      queries.push({
+        kind: 'fresh-author',
+        pubkey,
+        urls,
+        filter: perFilter
+      })
+    }
+  }
+
+  // One partial-author query per (author, subRequest group), each with
+  // that author's own `until`. This is the fix for the skip bug.
+  for (const pubkey of partialAuthors) {
+    const oldest = oldestByAuthor.get(pubkey)!
+    const prevFloor = floors.get(pubkey)
+    // Skip if we've already queried back to (or beyond) this author's
+    // current oldest and got nothing — unless the caller asks to dig deeper.
+    if (!deeper && prevFloor !== undefined && prevFloor <= oldest) continue
+
+    for (const { urls, filter } of subRequests) {
+      if (!(filter.authors ?? []).includes(pubkey)) continue
+      queries.push({
+        kind: 'partial',
+        pubkey,
+        urls,
+        filter: {
+          kinds: showKinds,
+          ...filter,
+          authors: [pubkey],
+          until: oldest - 1,
+          limit: input.partialLimit
+        }
+      })
+    }
+  }
+
+  return { queries, needy, freshAuthors, partialAuthors }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -160,6 +160,10 @@ export const DEFAULT_FEED_TABS: TFeedTabConfig[] = [
   { id: 'posts', builtin: 'posts', label: 'Notes', hideReplies: true },
   { id: 'postsAndReplies', builtin: 'postsAndReplies', label: 'Replies' },
   { id: '24h', builtin: '24h', label: '24h Pulse' },
+  // Deep per-author Pulse with backfill beyond 24h. Slower to load than
+  // the default `24h` Pulse, so it ships hidden by default; users can
+  // enable it from Customize tabs.
+  { id: 'pulse', builtin: 'pulse', label: 'Pulse', hidden: true },
   {
     id: 'articles',
     builtin: 'articles',

--- a/src/lib/pulse.ts
+++ b/src/lib/pulse.ts
@@ -1,0 +1,4 @@
+// Shared Pulse constants. Both DeepPulseList (the feed) and the
+// UserAggregationDetailPage write to the same Pulse IDB store, so they
+// must agree on the per-author cap.
+export const PULSE_EVENTS_PER_USER_CAP = 10

--- a/src/pages/secondary/UserAggregationDetailPage/index.tsx
+++ b/src/pages/secondary/UserAggregationDetailPage/index.tsx
@@ -1,10 +1,24 @@
 import NoteCard from '@/components/NoteCard'
 import { SimpleUsername } from '@/components/Username'
 import SecondaryPageLayout from '@/layouts/SecondaryPageLayout'
+import { PULSE_EVENTS_PER_USER_CAP } from '@/lib/pulse'
+import { getDefaultRelayUrls } from '@/lib/relay'
+import { mergeTimelines } from '@/lib/timeline'
+import client from '@/services/client.service'
+import indexedDb from '@/services/indexed-db.service'
 import userAggregationService from '@/services/user-aggregation.service'
+import { TSubRequestFilter } from '@/types'
 import { nip19, NostrEvent } from 'nostr-tools'
-import { forwardRef, useEffect, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+// Mirror the parent feed's `showKinds` (registered by DeepPulseList in
+// userAggregationService) so this page doesn't surface kinds the feed
+// itself filtered out (kind 30618, cashu wallet ops, etc.). When the
+// service has no kinds registered (e.g. deep-linking to /user-aggregation/
+// without first opening the feed), fall back to no kinds filter so the
+// user at least sees something.
+const FETCH_LIMIT = 50
 
 const UserAggregationDetailPage = forwardRef(
   (
@@ -20,7 +34,14 @@ const UserAggregationDetailPage = forwardRef(
     ref
   ) => {
     const { t } = useTranslation()
-    const [aggregation, setAggregation] = useState<NostrEvent[]>([])
+    const [serviceEvents, setServiceEvents] = useState<NostrEvent[]>([])
+    const [liveEvents, setLiveEvents] = useState<NostrEvent[]>([])
+    const [isPulseBackfilling, setIsPulseBackfilling] = useState(false)
+    const [isInitialLoading, setIsInitialLoading] = useState(true)
+    const [isLoadingMore, setIsLoadingMore] = useState(false)
+    const [hasMore, setHasMore] = useState(true)
+    const [timelineKey, setTimelineKey] = useState<string | undefined>(undefined)
+    const bottomRef = useRef<HTMLDivElement>(null)
 
     const pubkey = useMemo(() => {
       if (!npub) return undefined
@@ -33,25 +54,189 @@ const UserAggregationDetailPage = forwardRef(
       }
     }, [npub])
 
+    // Subscribe to the Pulse list's aggregation store for this user so events
+    // its backfill turns up while we're on this page show here too.
     useEffect(() => {
       if (!feedId || !pubkey) {
-        setAggregation([])
+        setServiceEvents([])
         return
       }
 
       const updateEvents = () => {
-        const events = userAggregationService.getAggregation(feedId, pubkey)
-        setAggregation(events)
+        const events = userAggregationService.getAggregation(feedId, pubkey) || []
+        setServiceEvents(events)
       }
 
-      const unSub = userAggregationService.subscribeAggregationChange(feedId, pubkey, () => {
+      const updateBackfill = () => {
+        setIsPulseBackfilling(userAggregationService.isBackfilling(feedId))
+      }
+
+      const unSubAgg = userAggregationService.subscribeAggregationChange(feedId, pubkey, () => {
         updateEvents()
       })
 
-      updateEvents()
+      const unSubBackfill = userAggregationService.subscribeBackfillChange(feedId, () => {
+        updateBackfill()
+      })
 
-      return unSub
-    }, [feedId, pubkey, setAggregation])
+      updateEvents()
+      updateBackfill()
+
+      return () => {
+        unSubAgg()
+        unSubBackfill()
+      }
+    }, [feedId, pubkey])
+
+    // Persist this author's events into the Pulse IDB cache so a subsequent
+    // visit to the Pulse list shows them instantly (instead of an empty row).
+    // Also bumps the per-author meta so the Pulse backfill planner skips
+    // overlapping fetches next session.
+    const persistPulseEvents = useCallback((events: NostrEvent[], authorPubkey: string) => {
+      const owned = events.filter((e) => e.pubkey === authorPubkey)
+      if (owned.length === 0) return
+      const items = owned.map((event) => ({
+        event,
+        relays: client.getEventHints(event.id)
+      }))
+      indexedDb.putPulseEvents(items, PULSE_EVENTS_PER_USER_CAP).catch(() => {
+        // IDB errors are non-fatal — the UI already has the events in state.
+      })
+      indexedDb
+        .putPulseAuthorMeta([
+          {
+            pubkey: authorPubkey,
+            lastCheckedAt: Math.floor(Date.now() / 1000),
+            lastCheckOk: true
+          }
+        ])
+        .catch(() => {})
+    }, [])
+
+    // Long-lived subscription against the author's write relays + defaults.
+    // Streaming (not one-shot) so slow relays still deliver events instead
+    // of timing out into an empty result, which was the regression here.
+    useEffect(() => {
+      if (!pubkey) {
+        setLiveEvents([])
+        setIsInitialLoading(false)
+        return
+      }
+
+      let cancelled = false
+      let closer: (() => void) | undefined
+
+      setIsInitialLoading(true)
+      setLiveEvents([])
+      setHasMore(true)
+      setTimelineKey(undefined)
+
+      const init = async () => {
+        const relayList = await client.fetchRelayList(pubkey)
+        if (cancelled) return
+        const relays = relayList.write.concat(getDefaultRelayUrls()).slice(0, 8)
+
+        const feedKinds = feedId
+          ? userAggregationService.getFeedKinds(feedId)
+          : undefined
+        const filter: TSubRequestFilter =
+          feedKinds && feedKinds.length > 0
+            ? { authors: [pubkey], kinds: feedKinds, limit: FETCH_LIMIT }
+            : { authors: [pubkey], limit: FETCH_LIMIT }
+
+        const { closer: _closer, timelineKey: _key } = await client.subscribeTimeline(
+          [{ urls: relays, filter }],
+          {
+            onEvents: (events, eosed) => {
+              if (cancelled) return
+              if (events.length > 0) {
+                setLiveEvents(events)
+                persistPulseEvents(events, pubkey)
+              }
+              if (eosed) {
+                setIsInitialLoading(false)
+              }
+            },
+            onNew: (event) => {
+              if (cancelled) return
+              setLiveEvents((prev) => mergeTimelines([[event], prev]))
+              persistPulseEvents([event], pubkey)
+            }
+          },
+          { needSort: true }
+        )
+
+        if (cancelled) {
+          _closer()
+          return
+        }
+        closer = _closer
+        setTimelineKey(_key)
+      }
+
+      init().catch(() => {
+        if (!cancelled) setIsInitialLoading(false)
+      })
+
+      return () => {
+        cancelled = true
+        if (closer) closer()
+      }
+    }, [pubkey, persistPulseEvents])
+
+    // Merge service + subscription events, deduplicated, newest first.
+    const allEvents = useMemo(() => {
+      const combined = [...serviceEvents, ...liveEvents]
+      const seen = new Set<string>()
+      const deduped = combined.filter((e) => {
+        if (seen.has(e.id)) return false
+        seen.add(e.id)
+        return true
+      })
+      return deduped.sort((a, b) => b.created_at - a.created_at)
+    }, [serviceEvents, liveEvents])
+
+    // Fetch the next older batch via the existing timeline.
+    const fetchMore = useCallback(async () => {
+      if (!pubkey || !timelineKey || isLoadingMore || !hasMore) return
+      setIsLoadingMore(true)
+      try {
+        const until = allEvents.length
+          ? allEvents[allEvents.length - 1].created_at - 1
+          : Math.floor(Date.now() / 1000)
+        const olderEvents = await client.loadMoreTimeline(timelineKey, until, FETCH_LIMIT)
+        if (olderEvents.length === 0) {
+          setHasMore(false)
+        } else {
+          setLiveEvents((prev) => mergeTimelines([prev, olderEvents]))
+          persistPulseEvents(olderEvents, pubkey)
+        }
+      } catch {
+        // Network blip — leave hasMore true so the user can retry by scrolling
+      } finally {
+        setIsLoadingMore(false)
+      }
+    }, [pubkey, timelineKey, isLoadingMore, hasMore, allEvents, persistPulseEvents])
+
+    // Infinite-scroll observer
+    useEffect(() => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            fetchMore()
+          }
+        },
+        { rootMargin: '400px', threshold: 0 }
+      )
+
+      const el = bottomRef.current
+      if (el) observer.observe(el)
+      return () => {
+        if (el) observer.unobserve(el)
+      }
+    }, [fetchMore])
+
+    const isLoading = isPulseBackfilling || isInitialLoading || isLoadingMore
 
     if (!pubkey || !feedId) {
       return (
@@ -71,10 +256,30 @@ const UserAggregationDetailPage = forwardRef(
         displayScrollToTopButton
       >
         <div className="min-h-screen">
-          {aggregation.map((event) => (
+          {allEvents.map((event) => (
             <NoteCard key={event.id} className="w-full" event={event} filterMutedNotes={false} />
           ))}
-          <div className="mt-2 text-center text-sm text-muted-foreground">{t('no more notes')}</div>
+
+          <div ref={bottomRef} className="py-4">
+            {isLoading ? (
+              <div className="text-center text-sm text-muted-foreground">
+                {t('loading more notes')}
+              </div>
+            ) : hasMore ? (
+              // Sentinel — observer triggers fetchMore when this comes into view
+              <div className="text-center text-sm text-muted-foreground">
+                {t('loading more notes')}
+              </div>
+            ) : allEvents.length > 0 ? (
+              <div className="text-center text-sm text-muted-foreground">
+                {t('no more notes')}
+              </div>
+            ) : (
+              <div className="text-center text-sm text-muted-foreground">
+                {t('no more notes')}
+              </div>
+            )}
+          </div>
         </div>
       </SecondaryPageLayout>
     )

--- a/src/services/indexed-db.service.ts
+++ b/src/services/indexed-db.service.ts
@@ -29,6 +29,17 @@ const StoreNames = {
   DECRYPTED_CONTENTS: 'decryptedContents',
   PINNED_USERS_EVENTS: 'pinnedUsersEvents',
   EVENTS: 'events',
+  // Per-author cache used by the Pulse view. Unlike EVENTS (which is
+  // time-pruned every 5 days), PULSE_EVENTS is capped per author so inactive
+  // follows' old posts stay cached indefinitely. Keyed by event id, indexed
+  // by pubkey and by created_at.
+  PULSE_EVENTS: 'pulseEvents',
+  // Per-author metadata for the Pulse view: when we last successfully
+  // checked for new posts, and whether that check succeeded. Lets the next
+  // check send `since: lastCheckedAt` instead of an unbounded query, so we
+  // only fill the gap rather than re-fetching the whole timeline. Keyed by
+  // pubkey.
+  PULSE_AUTHOR_META: 'pulseAuthorMeta',
   DM_CONVERSATIONS: 'dmConversations',
   DM_MESSAGES: 'dmMessages',
   DM_RELAYS_EVENTS: 'dmRelaysEvents',
@@ -120,6 +131,21 @@ class IndexedDbService {
               keyPath: 'event.id'
             })
             feedEventsStore.createIndex('createdAtIndex', 'event.created_at')
+          }
+          if (!db.objectStoreNames.contains(StoreNames.PULSE_EVENTS)) {
+            const pulseStore = db.createObjectStore(StoreNames.PULSE_EVENTS, {
+              keyPath: 'event.id'
+            })
+            pulseStore.createIndex('pubkeyIndex', 'event.pubkey')
+            pulseStore.createIndex(
+              'pubkeyCreatedAtIndex',
+              ['event.pubkey', 'event.created_at']
+            )
+          }
+          if (!db.objectStoreNames.contains(StoreNames.PULSE_AUTHOR_META)) {
+            db.createObjectStore(StoreNames.PULSE_AUTHOR_META, {
+              keyPath: 'pubkey'
+            })
           }
           if (!db.objectStoreNames.contains(StoreNames.DM_CONVERSATIONS)) {
             const dmConversationsStore = db.createObjectStore(StoreNames.DM_CONVERSATIONS, {
@@ -683,6 +709,172 @@ class IndexedDbService {
       request.onerror = (event) => {
         transaction.commit()
         reject(event)
+      }
+    })
+  }
+
+  // ----- Pulse per-author cache ---------------------------------------
+
+  // Store events for the Pulse view. We cap to `perAuthorCap` most-recent
+  // events per author so the store stays bounded even after years of use.
+  // Each call:
+  //   1) writes the new events,
+  //   2) for every affected pubkey, drops any record beyond the cap.
+  // Cap trimming happens inside the same transaction so the store never
+  // holds more than cap*authors records.
+  async putPulseEvents(
+    items: { event: Event; relays: string[] }[],
+    perAuthorCap: number
+  ): Promise<void> {
+    await this.initPromise
+    if (!this.db) return
+    if (items.length === 0) return
+
+    const db = this.db
+    const affectedPubkeys = new Set(items.map((i) => i.event.pubkey))
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(StoreNames.PULSE_EVENTS, 'readwrite')
+      const store = transaction.objectStore(StoreNames.PULSE_EVENTS)
+      const index = store.index('pubkeyCreatedAtIndex')
+
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = (ev) => reject(ev)
+      transaction.onabort = (ev) => reject(ev)
+
+      // 1) Upsert all new items.
+      for (const item of items) {
+        store.put(item)
+      }
+
+      // 2) For each affected pubkey, keep only the top N by created_at.
+      //    We walk the index in reverse (newest first) and delete anything
+      //    past the cap.
+      for (const pubkey of affectedPubkeys) {
+        const range = IDBKeyRange.bound(
+          [pubkey, -Infinity],
+          [pubkey, Infinity]
+        )
+        const req = index.openCursor(range, 'prev')
+        let kept = 0
+        req.onsuccess = (ev) => {
+          const cursor = (ev.target as IDBRequest).result as
+            | IDBCursorWithValue
+            | null
+          if (!cursor) return
+          if (kept < perAuthorCap) {
+            kept++
+            cursor.continue()
+          } else {
+            cursor.delete()
+            cursor.continue()
+          }
+        }
+      }
+    })
+  }
+
+  // Return up to `perAuthorCap` most-recent cached events for each of the
+  // given pubkeys. Used to hydrate the Pulse view instantly on open.
+  async getPulseEventsForAuthors(
+    pubkeys: string[],
+    perAuthorCap: number
+  ): Promise<Event[]> {
+    await this.initPromise
+    if (!this.db) return []
+    if (pubkeys.length === 0) return []
+
+    const db = this.db
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(StoreNames.PULSE_EVENTS, 'readonly')
+      const store = transaction.objectStore(StoreNames.PULSE_EVENTS)
+      const index = store.index('pubkeyCreatedAtIndex')
+      const out: Event[] = []
+
+      let pending = pubkeys.length
+      const done = () => {
+        pending--
+        if (pending === 0) {
+          resolve(out)
+        }
+      }
+
+      for (const pubkey of pubkeys) {
+        const range = IDBKeyRange.bound(
+          [pubkey, -Infinity],
+          [pubkey, Infinity]
+        )
+        const req = index.openCursor(range, 'prev')
+        let collected = 0
+        req.onsuccess = (ev) => {
+          const cursor = (ev.target as IDBRequest).result as
+            | IDBCursorWithValue
+            | null
+          if (!cursor || collected >= perAuthorCap) {
+            done()
+            return
+          }
+          const item = cursor.value as { event: Event; relays: string[] }
+          out.push(item.event)
+          collected++
+          cursor.continue()
+        }
+        req.onerror = (ev) => reject(ev)
+      }
+    })
+  }
+
+  // Bulk set last-checked timestamps for Pulse authors. Only call this
+  // AFTER a successful fetch for that author — timeout / network errors
+  // must leave the previous timestamp untouched so the next attempt
+  // still fills the whole missed window.
+  async putPulseAuthorMeta(
+    items: { pubkey: string; lastCheckedAt: number; lastCheckOk: boolean }[]
+  ): Promise<void> {
+    await this.initPromise
+    if (!this.db) return
+    if (items.length === 0) return
+
+    const db = this.db
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(StoreNames.PULSE_AUTHOR_META, 'readwrite')
+      const store = transaction.objectStore(StoreNames.PULSE_AUTHOR_META)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = (ev) => reject(ev)
+      transaction.onabort = (ev) => reject(ev)
+      for (const item of items) {
+        store.put(item)
+      }
+    })
+  }
+
+  async getPulseAuthorMeta(
+    pubkeys: string[]
+  ): Promise<Map<string, { lastCheckedAt: number; lastCheckOk: boolean }>> {
+    await this.initPromise
+    const out = new Map<string, { lastCheckedAt: number; lastCheckOk: boolean }>()
+    if (!this.db) return out
+    if (pubkeys.length === 0) return out
+
+    const db = this.db
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(StoreNames.PULSE_AUTHOR_META, 'readonly')
+      const store = transaction.objectStore(StoreNames.PULSE_AUTHOR_META)
+      let pending = pubkeys.length
+      const done = () => {
+        pending--
+        if (pending === 0) resolve(out)
+      }
+      for (const pubkey of pubkeys) {
+        const req = store.get(pubkey)
+        req.onsuccess = () => {
+          const v = req.result as
+            | { pubkey: string; lastCheckedAt: number; lastCheckOk: boolean }
+            | undefined
+          if (v) out.set(pubkey, { lastCheckedAt: v.lastCheckedAt, lastCheckOk: v.lastCheckOk })
+          done()
+        }
+        req.onerror = (ev) => reject(ev)
       }
     })
   }

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -136,7 +136,25 @@ class LocalStorageService {
               typeof tab.label === 'string'
           )
           if (valid.length > 0) {
-            this.feedTabs = valid
+            // Backfill any default builtin tabs the user has never seen
+            // before (e.g. ones added in a later version). They're appended
+            // at the end with their default `hidden` value preserved, so
+            // they show up in Customize tabs and the user can enable them
+            // without losing their existing layout.
+            const knownIds = new Set(valid.map((tab) => tab.id))
+            const knownBuiltins = new Set(
+              valid.map((tab) => tab.builtin).filter((b): b is NonNullable<typeof b> => !!b)
+            )
+            const missingDefaults = DEFAULT_FEED_TABS.filter(
+              (tab) => !knownIds.has(tab.id) && !(tab.builtin && knownBuiltins.has(tab.builtin))
+            ).map((tab) => ({ ...tab }))
+            this.feedTabs = [...valid, ...missingDefaults]
+            if (missingDefaults.length > 0) {
+              window.localStorage.setItem(
+                StorageKey.FEED_TABS,
+                JSON.stringify(this.feedTabs)
+              )
+            }
           }
         }
       } catch {

--- a/src/services/user-aggregation.service.ts
+++ b/src/services/user-aggregation.service.ts
@@ -16,6 +16,12 @@ class UserAggregationService {
   private aggregationStore: Map<string, Map<string, Event[]>> = new Map()
   private listenersMap: Map<string, Set<() => void>> = new Map()
   private lastViewedMap: Map<string, number> = new Map()
+  private backfillingFeeds: Set<string> = new Set()
+  // Effective `showKinds` for each pulse feed, registered by DeepPulseList so
+  // the per-author detail page can subscribe with the same filter (otherwise
+  // it would surface every kind the author posts, including the ones Jumble
+  // can't render).
+  private feedKindsMap: Map<string, number[]> = new Map()
 
   constructor() {
     if (UserAggregationService.instance) {
@@ -155,6 +161,31 @@ class UserAggregationService {
     const lastViewed = this.lastViewedMap.get(key)
 
     return lastViewed ?? 0
+  }
+
+  setFeedKinds(feedId: string, kinds: number[]) {
+    this.feedKindsMap.set(feedId, kinds)
+  }
+
+  getFeedKinds(feedId: string): number[] | undefined {
+    return this.feedKindsMap.get(feedId)
+  }
+
+  setBackfilling(feedId: string, backfilling: boolean) {
+    if (backfilling) {
+      this.backfillingFeeds.add(feedId)
+    } else {
+      this.backfillingFeeds.delete(feedId)
+    }
+    this.notify(`backfill:${feedId}`)
+  }
+
+  isBackfilling(feedId: string): boolean {
+    return this.backfillingFeeds.has(feedId)
+  }
+
+  subscribeBackfillChange(feedId: string, listener: () => void) {
+    return this.subscribe(`backfill:${feedId}`, listener)
   }
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -149,7 +149,7 @@ export type TPostTargetItem =
 
 export type TNoteListMode = 'posts' | 'postsAndReplies' | 'you' | '24h' | 'articles'
 
-export type TFeedTabBuiltin = 'posts' | 'postsAndReplies' | '24h' | 'articles'
+export type TFeedTabBuiltin = 'posts' | 'postsAndReplies' | '24h' | 'articles' | 'pulse'
 
 export type TFeedTabConfig = {
   id: string


### PR DESCRIPTION
- Add DeepPulseList component for deep per-author pulse aggregation
- Add pulse-backfill service with spec tests
- Add UserAggregationDetailPage updates for deep pulse view
- Update indexed-db, local-storage and user-aggregation services
- Cache 10 events per follow in IDB separate from the events cache