### PR TITLE
Keep zap status visible across navigation

### DIFF
--- a/src/__tests__/zap-status-toast.spec.ts
+++ b/src/__tests__/zap-status-toast.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { trackZapStatus } from '@/lib/zap-status-toast'
+import { toast } from 'sonner'
+
+vi.mock('sonner', () => ({
+  toast: {
+    promise: vi.fn((promise: Promise<unknown>) => ({
+      unwrap: () => promise
+    }))
+  }
+}))
+
+const messages = {
+  loading: 'Zapping...',
+  success: 'Zap sent!',
+  canceled: 'Zap canceled',
+  error: (error: unknown) => `Zap failed: ${(error as Error).message}`
+}
+
+describe('trackZapStatus', () => {
+  it('keeps zap progress in a global toast and resolves with the zap result', async () => {
+    const zapResult = { preimage: 'preimage', invoice: 'invoice' }
+    const promise = Promise.resolve(zapResult)
+
+    await expect(trackZapStatus(promise, messages)).resolves.toEqual(zapResult)
+
+    expect(toast.promise).toHaveBeenCalledWith(
+      promise,
+      expect.objectContaining({
+        loading: messages.loading,
+        success: expect.any(Function),
+        error: messages.error
+      })
+    )
+
+    const toastOptions = vi.mocked(toast.promise).mock.calls[0][1]
+    const success = toastOptions?.success
+    expect(success).toEqual(expect.any(Function))
+    if (typeof success !== 'function') {
+      throw new Error('Expected zap status toast success handler to be a function')
+    }
+    expect(success(zapResult)).toBe(messages.success)
+    expect(success(null)).toBe(messages.canceled)
+  })
+})

--- a/src/components/StuffStats/ZapButton.tsx
+++ b/src/components/StuffStats/ZapButton.tsx
@@ -6,13 +6,11 @@ import { cn } from '@/lib/utils'
 import { useNostr } from '@/providers/NostrProvider'
 import { useZap } from '@/providers/ZapProvider'
 import client from '@/services/client.service'
-import lightning from '@/services/lightning.service'
 import stuffStatsService from '@/services/stuff-stats.service'
 import { Loader, Zap } from 'lucide-react'
 import { Event } from 'nostr-tools'
 import { MouseEvent, TouchEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
 import ZapDialog from '../ZapDialog'
 
 export default function ZapButton({ stuff }: { stuff: Event | string }) {
@@ -20,7 +18,7 @@ export default function ZapButton({ stuff }: { stuff: Event | string }) {
   const { checkLogin, pubkey } = useNostr()
   const { event, stuffKey } = useStuff(stuff)
   const noteStats = useStuffStatsById(stuffKey)
-  const { defaultZapSats, defaultZapComment, quickZap } = useZap()
+  const { defaultZapSats, defaultZapComment, quickZap, zap } = useZap()
   const [touchStart, setTouchStart] = useState<{ x: number; y: number } | null>(null)
   const [openZapDialog, setOpenZapDialog] = useState(false)
   const [zapping, setZapping] = useState(false)
@@ -55,7 +53,7 @@ export default function ZapButton({ stuff }: { stuff: Event | string }) {
       if (zapping || !event) return
 
       setZapping(true)
-      const zapResult = await lightning.zap(pubkey, event, defaultZapSats, defaultZapComment)
+      const zapResult = await zap(pubkey, event, defaultZapSats, defaultZapComment)
       // user canceled
       if (!zapResult) {
         return
@@ -67,8 +65,8 @@ export default function ZapButton({ stuff }: { stuff: Event | string }) {
         defaultZapSats,
         defaultZapComment
       )
-    } catch (error) {
-      toast.error(`${t('Zap failed')}: ${(error as Error).message}`)
+    } catch (_error) {
+      // The global zap status toast reports the error and stays visible after navigation.
     } finally {
       setZapping(false)
     }

--- a/src/components/ZapDialog/index.tsx
+++ b/src/components/ZapDialog/index.tsx
@@ -18,13 +18,11 @@ import { Label } from '@/components/ui/label'
 import { useNostr } from '@/providers/NostrProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import { useZap } from '@/providers/ZapProvider'
-import lightning from '@/services/lightning.service'
 import stuffStatsService from '@/services/stuff-stats.service'
 import { Loader } from 'lucide-react'
 import { NostrEvent } from 'nostr-tools'
 import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
 import UserAvatar from '../UserAvatar'
 import Username from '../Username'
 
@@ -136,7 +134,7 @@ function ZapDialogContent({
 }) {
   const { t, i18n } = useTranslation()
   const { pubkey } = useNostr()
-  const { defaultZapSats, defaultZapComment } = useZap()
+  const { defaultZapSats, defaultZapComment, zap } = useZap()
   const [sats, setSats] = useState(defaultAmount ?? defaultZapSats)
   const [comment, setComment] = useState(defaultComment ?? defaultZapComment)
   const isSelfZap = useMemo(() => pubkey === recipient, [pubkey, recipient])
@@ -181,7 +179,7 @@ function ZapDialogContent({
         throw new Error('You need to be logged in to zap')
       }
       setZapping(true)
-      const zapResult = await lightning.zap(pubkey, event ?? recipient, sats, comment, () =>
+      const zapResult = await zap(pubkey, event ?? recipient, sats, comment, () =>
         setOpen(false)
       )
       // user canceled
@@ -191,8 +189,8 @@ function ZapDialogContent({
       if (event) {
         stuffStatsService.addZap(pubkey, event.id, zapResult.invoice, sats, comment)
       }
-    } catch (error) {
-      toast.error(`${t('Zap failed')}: ${(error as Error).message}`)
+    } catch (_error) {
+      // The global zap status toast reports the error and stays visible after navigation.
     } finally {
       setZapping(false)
     }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -899,6 +899,10 @@ export default {
     'Connect wallet': 'Connect wallet',
     'Connect wallet via NWC': 'Connect wallet via NWC',
     'Use any NWC-compatible Lightning wallet': 'Use any NWC-compatible Lightning wallet',
-    'Quickly create a custodial Lightning vault': 'Quickly create a custodial Lightning vault'
+    'Quickly create a custodial Lightning vault': 'Quickly create a custodial Lightning vault',
+    'Zapping...': 'Zapping...',
+    'Zap sent!': 'Zap sent!',
+    'Zap canceled': 'Zap canceled',
+    'Zap failed': 'Zap failed'
   }
 }

--- a/src/lib/zap-status-toast.ts
+++ b/src/lib/zap-status-toast.ts
@@ -1,0 +1,24 @@
+import { toast } from 'sonner'
+
+export type TZapStatusResult = { preimage: string; invoice: string } | null
+
+export type TZapStatusMessages = {
+  loading: string
+  success: string
+  canceled: string
+  error: (error: unknown) => string
+}
+
+export function trackZapStatus<T extends TZapStatusResult>(
+  promise: Promise<T>,
+  messages: TZapStatusMessages
+): Promise<T> {
+  const { unwrap } = toast.promise(promise, {
+    loading: messages.loading,
+    success: (result) => (result ? messages.success : messages.canceled),
+    error: messages.error,
+    duration: 10_000
+  })
+
+  return unwrap()
+}

--- a/src/providers/ZapProvider.tsx
+++ b/src/providers/ZapProvider.tsx
@@ -1,8 +1,12 @@
 import lightningService from '@/services/lightning.service'
+import { formatError } from '@/lib/error'
+import { trackZapStatus, TZapStatusResult } from '@/lib/zap-status-toast'
 import storage from '@/services/local-storage.service'
 import { onConnected, onDisconnected } from '@getalby/bitcoin-connect-react'
 import { GetInfoResponse, WebLNProvider } from '@webbtc/webln-types'
+import { NostrEvent } from 'nostr-tools'
 import { createContext, useContext, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 type TZapContext = {
   isWalletConnected: boolean
@@ -14,6 +18,13 @@ type TZapContext = {
   updateDefaultComment: (comment: string) => void
   quickZap: boolean
   updateQuickZap: (quickZap: boolean) => void
+  zap: (
+    sender: string,
+    recipientOrEvent: string | NostrEvent,
+    sats: number,
+    comment: string,
+    closeOuterModel?: () => void
+  ) => Promise<TZapStatusResult>
 }
 
 const ZapContext = createContext<TZapContext | undefined>(undefined)
@@ -27,6 +38,7 @@ export const useZap = () => {
 }
 
 export function ZapProvider({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation()
   const [defaultZapSats, setDefaultZapSats] = useState<number>(storage.getDefaultZapSats())
   const [defaultZapComment, setDefaultZapComment] = useState<string>(storage.getDefaultZapComment())
   const [quickZap, setQuickZap] = useState<boolean>(storage.getQuickZap())
@@ -69,6 +81,24 @@ export function ZapProvider({ children }: { children: React.ReactNode }) {
     setQuickZap(quickZap)
   }
 
+  const zap = (
+    sender: string,
+    recipientOrEvent: string | NostrEvent,
+    sats: number,
+    comment: string,
+    closeOuterModel?: () => void
+  ) => {
+    return trackZapStatus(
+      lightningService.zap(sender, recipientOrEvent, sats, comment, closeOuterModel),
+      {
+        loading: t('Zapping...'),
+        success: t('Zap sent!'),
+        canceled: t('Zap canceled'),
+        error: (error) => `${t('Zap failed')}: ${formatError(error).join('; ')}`
+      }
+    )
+  }
+
   return (
     <ZapContext.Provider
       value={{
@@ -80,7 +110,8 @@ export function ZapProvider({ children }: { children: React.ReactNode }) {
         defaultZapComment,
         updateDefaultComment,
         quickZap,
-        updateQuickZap
+        updateQuickZap,
+        zap
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- route quick zaps and dialog zaps through the root ZapProvider
- wrap zap promises in a global sonner toast so pending/success/cancel/failure state survives page navigation and dialog unmounts
- add a small unit test for the zap status toast wrapper

Fixes #159

## Verification
- `npm test`
- `npm run lint`
- `npm run build`

Note: `npm run build` prints existing warnings for `Invalid URL: wss://` and large chunks, but exits 0.