### PR TITLE
Add NIP-05 domain mute filter

### DIFF
--- a/src/components/NoteCard/RepostNoteCard.tsx
+++ b/src/components/NoteCard/RepostNoteCard.tsx
@@ -1,6 +1,8 @@
 import { isMentioningMutedUsers } from '@/lib/event'
+import { isProfileMutedByNip05Domain } from '@/lib/muted-nip05'
 import { generateBech32IdFromATag, generateBech32IdFromETag, tagNameEquals } from '@/lib/tag'
 import { useContentPolicy } from '@/providers/ContentPolicyProvider'
+import { useFollowList } from '@/providers/FollowListProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
 import client from '@/services/client.service'
 import threadService from '@/services/thread.service'
@@ -22,18 +24,35 @@ export default function RepostNoteCard({
   reposters?: string[]
 }) {
   const { mutePubkeySet } = useMuteList()
-  const { hideContentMentioningMutedUsers } = useContentPolicy()
+  const { followingSet } = useFollowList()
+  const { hideContentMentioningMutedUsers, mutedNip05Domains } = useContentPolicy()
   const [targetEvent, setTargetEvent] = useState<Event | null>(null)
+  const [targetNip05CheckPending, setTargetNip05CheckPending] = useState(false)
+  const [targetMutedByNip05Domain, setTargetMutedByNip05Domain] = useState(false)
+  const mutedNip05DomainSet = useMemo(
+    () => new Set(mutedNip05Domains),
+    [mutedNip05Domains]
+  )
   const shouldHide = useMemo(() => {
     if (!targetEvent) return true
     if (filterMutedNotes && mutePubkeySet.has(targetEvent.pubkey)) {
+      return true
+    }
+    if (filterMutedNotes && (targetNip05CheckPending || targetMutedByNip05Domain)) {
       return true
     }
     if (hideContentMentioningMutedUsers && isMentioningMutedUsers(targetEvent, mutePubkeySet)) {
       return true
     }
     return false
-  }, [targetEvent, filterMutedNotes, hideContentMentioningMutedUsers, mutePubkeySet])
+  }, [
+    targetEvent,
+    filterMutedNotes,
+    mutePubkeySet,
+    targetNip05CheckPending,
+    targetMutedByNip05Domain,
+    hideContentMentioningMutedUsers
+  ])
   useEffect(() => {
     const fetch = async () => {
       let eventFromContent: Event | null = null
@@ -86,6 +105,41 @@ export default function RepostNoteCard({
     }
     fetch()
   }, [event])
+
+  useEffect(() => {
+    let cancelled = false
+
+    setTargetNip05CheckPending(false)
+    setTargetMutedByNip05Domain(false)
+
+    if (
+      !targetEvent ||
+      !filterMutedNotes ||
+      mutedNip05DomainSet.size === 0 ||
+      followingSet.has(targetEvent.pubkey)
+    ) {
+      return
+    }
+
+    setTargetNip05CheckPending(true)
+    client
+      .fetchProfile(targetEvent.pubkey)
+      .then((profile) => {
+        if (cancelled) return
+        setTargetMutedByNip05Domain(
+          isProfileMutedByNip05Domain(profile, mutedNip05DomainSet, followingSet)
+        )
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setTargetNip05CheckPending(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [targetEvent, filterMutedNotes, mutedNip05DomainSet, followingSet])
 
   if (!targetEvent || shouldHide) return null
 

--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -4,9 +4,11 @@ import { SPAMMER_PERCENTILE_THRESHOLD } from '@/constants'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { getEventKey, getKeyFromTag, isMentioningMutedUsers, isReplyNoteEvent } from '@/lib/event'
 import { tagNameEquals } from '@/lib/tag'
+import { getPubkeysMutedByNip05Domain } from '@/lib/muted-nip05'
 import { mergeTimelines } from '@/lib/timeline'
 import { useContentPolicy } from '@/providers/ContentPolicyProvider'
 import { useDeletedEvent } from '@/providers/DeletedEventProvider'
+import { useFollowList } from '@/providers/FollowListProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
 import { useNostr } from '@/providers/NostrProvider'
 import { usePageActive } from '@/providers/PageActiveProvider'
@@ -36,6 +38,20 @@ import PinnedNoteCard from '../PinnedNoteCard'
 const LIMIT = 200
 const ALGO_LIMIT = 500
 const SHOW_COUNT = 10
+
+const getEmbeddedRepostEvents = (events: Event[]) => {
+  return events
+    .map((evt) => {
+      if (evt.kind !== kinds.Repost && evt.kind !== kinds.GenericRepost) return null
+      if (!evt.content) return null
+      try {
+        return JSON.parse(evt.content) as Event
+      } catch {
+        return null
+      }
+    })
+    .filter((event): event is Event => !!event)
+}
 
 export type TNoteListRef = {
   scrollToTop: (behavior?: ScrollBehavior) => void
@@ -83,7 +99,8 @@ const NoteList = forwardRef<
     const { startLogin } = useNostr()
     const { isSpammer, meetsMinTrustScore } = useUserTrust()
     const { mutePubkeySet } = useMuteList()
-    const { hideContentMentioningMutedUsers, mutedWords } = useContentPolicy()
+    const { followingSet } = useFollowList()
+    const { hideContentMentioningMutedUsers, mutedWords, mutedNip05Domains } = useContentPolicy()
     const { isEventDeleted } = useDeletedEvent()
     const [storedEvents, setStoredEvents] = useState<Event[]>([])
     const [events, setEvents] = useState<Event[]>([])
@@ -121,11 +138,31 @@ const NoteList = forwardRef<
       return set
     }, [pinnedEventIds?.join(',')])
 
+    const mutedNip05DomainSet = useMemo(
+      () => new Set(mutedNip05Domains),
+      [mutedNip05Domains]
+    )
+
+    const getMutedNip05PubkeySet = useCallback(
+      async (events: Event[]) => {
+        if (!filterMutedNotes || mutedNip05DomainSet.size === 0) return new Set<string>()
+
+        return getPubkeysMutedByNip05Domain(
+          events.map((event) => event.pubkey),
+          mutedNip05DomainSet,
+          followingSet,
+          (pubkey) => client.fetchProfile(pubkey)
+        )
+      },
+      [filterMutedNotes, mutedNip05DomainSet, followingSet]
+    )
+
     const shouldHideEvent = useCallback(
-      (evt: Event) => {
+      (evt: Event, mutedNip05PubkeySet = new Set<string>()) => {
         if (pinnedEventHexIdSet.has(evt.id)) return true
         if (isEventDeleted(evt)) return true
         if (filterMutedNotes && mutePubkeySet.has(evt.pubkey)) return true
+        if (filterMutedNotes && mutedNip05PubkeySet.has(evt.pubkey)) return true
         if (
           filterMutedNotes &&
           hideContentMentioningMutedUsers &&
@@ -147,7 +184,15 @@ const NoteList = forwardRef<
 
         return false
       },
-      [mutePubkeySet, isEventDeleted, filterFn, mutedWords, pinnedEventHexIdSet]
+      [
+        mutePubkeySet,
+        isEventDeleted,
+        filterMutedNotes,
+        hideContentMentioningMutedUsers,
+        filterFn,
+        mutedWords,
+        pinnedEventHexIdSet
+      ]
     )
 
     useEffect(() => {
@@ -167,12 +212,16 @@ const NoteList = forwardRef<
         ) {
           mergedEvents = mergeTimelines([storedEvents, events])
         }
+        const mutedNip05PubkeySet = await getMutedNip05PubkeySet([
+          ...mergedEvents,
+          ...getEmbeddedRepostEvents(mergedEvents)
+        ])
         mergedEvents.forEach((evt) => {
           const key = getEventKey(evt)
           if (keySet.has(key)) return
           keySet.add(key)
 
-          if (shouldHideEvent(evt)) return
+          if (shouldHideEvent(evt, mutedNip05PubkeySet)) return
           if (hideReplies && isReplyNoteEvent(evt)) return
           if (evt.kind !== kinds.Repost && evt.kind !== kinds.GenericRepost) {
             filteredEvents.push(evt)
@@ -201,7 +250,7 @@ const NoteList = forwardRef<
               ) {
                 return
               }
-              if (shouldHideEvent(evt)) return
+              if (shouldHideEvent(eventFromContent, mutedNip05PubkeySet)) return
 
               targetEventKey = getEventKey(eventFromContent)
             }
@@ -264,6 +313,7 @@ const NoteList = forwardRef<
       events,
       storedEvents,
       shouldHideEvent,
+      getMutedNip05PubkeySet,
       hideReplies,
       hideSpam,
       meetsMinTrustScore,
@@ -278,9 +328,10 @@ const NoteList = forwardRef<
       const processNewEvents = async () => {
         const keySet = new Set<string>()
         const filteredEvents: Event[] = []
+        const mutedNip05PubkeySet = await getMutedNip05PubkeySet(newEvents)
 
         newEvents.forEach((event) => {
-          if (shouldHideEvent(event)) return
+          if (shouldHideEvent(event, mutedNip05PubkeySet)) return
           if (hideReplies && isReplyNoteEvent(event)) return
 
           const key = getEventKey(event)
@@ -316,7 +367,15 @@ const NoteList = forwardRef<
         setFilteredNewEvents(_filteredNotes)
       }
       processNewEvents()
-    }, [newEvents, shouldHideEvent, isSpammer, hideSpam, meetsMinTrustScore, trustScoreThreshold])
+    }, [
+      newEvents,
+      shouldHideEvent,
+      getMutedNip05PubkeySet,
+      isSpammer,
+      hideSpam,
+      meetsMinTrustScore,
+      trustScoreThreshold
+    ])
 
     const scrollToTop = (behavior: ScrollBehavior = 'instant') => {
       setTimeout(() => {

--- a/src/components/UserAggregationList/index.tsx
+++ b/src/components/UserAggregationList/index.tsx
@@ -5,11 +5,13 @@ import UserAvatar, { SimpleUserAvatar, UserAvatarSkeleton } from '@/components/U
 import Username, { SimpleUsername } from '@/components/Username'
 import { isMentioningMutedUsers } from '@/lib/event'
 import { toNote, toUserAggregationDetail } from '@/lib/link'
+import { getPubkeysMutedByNip05Domain } from '@/lib/muted-nip05'
 import { mergeTimelines } from '@/lib/timeline'
 import { cn, isTouchDevice } from '@/lib/utils'
 import { useSecondaryPage } from '@/PageManager'
 import { useContentPolicy } from '@/providers/ContentPolicyProvider'
 import { useDeletedEvent } from '@/providers/DeletedEventProvider'
+import { useFollowList } from '@/providers/FollowListProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
 import { useNostr } from '@/providers/NostrProvider'
 import { usePageActive } from '@/providers/PageActiveProvider'
@@ -75,9 +77,10 @@ const UserAggregationList = forwardRef<
     const { pubkey: currentPubkey, startLogin } = useNostr()
     const { push } = useSecondaryPage()
     const { mutePubkeySet } = useMuteList()
+    const { followingSet } = useFollowList()
     const { pinnedPubkeySet } = usePinnedUsers()
     const { meetsMinTrustScore } = useUserTrust()
-    const { hideContentMentioningMutedUsers } = useContentPolicy()
+    const { hideContentMentioningMutedUsers, mutedNip05Domains } = useContentPolicy()
     const { isEventDeleted } = useDeletedEvent()
     const [since, setSince] = useState(() => dayjs().subtract(1, 'day').unix())
     const [storedEvents, setStoredEvents] = useState<Event[]>([])
@@ -104,6 +107,11 @@ const UserAggregationList = forwardRef<
       : events.length
         ? events[0].created_at + 1
         : undefined
+
+    const mutedNip05DomainSet = useMemo(
+      () => new Set(mutedNip05Domains),
+      [mutedNip05Domains]
+    )
 
     const scrollToTop = (behavior: ScrollBehavior = 'instant') => {
       setTimeout(() => {
@@ -270,12 +278,23 @@ const UserAggregationList = forwardRef<
 
     const filterEvents = useCallback(
       async (events: Event[]) => {
+        const mutedNip05PubkeySet =
+          filterMutedNotes && mutedNip05DomainSet.size > 0
+            ? await getPubkeysMutedByNip05Domain(
+                events.map((event) => event.pubkey),
+                mutedNip05DomainSet,
+                followingSet,
+                (pubkey) => client.fetchProfile(pubkey)
+              )
+            : new Set<string>()
+
         const results = await Promise.allSettled(
           events.map(async (evt) => {
             if (evt.pubkey === currentPubkey) return null
             if (evt.created_at < since) return null
             if (isEventDeleted(evt)) return null
             if (filterMutedNotes && mutePubkeySet.has(evt.pubkey)) return null
+            if (filterMutedNotes && mutedNip05PubkeySet.has(evt.pubkey)) return null
             if (
               filterMutedNotes &&
               hideContentMentioningMutedUsers &&
@@ -299,6 +318,8 @@ const UserAggregationList = forwardRef<
       },
       [
         mutePubkeySet,
+        mutedNip05DomainSet,
+        followingSet,
         isEventDeleted,
         currentPubkey,
         filterMutedNotes,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,7 @@ export const StorageKey = {
   NSFW_DISPLAY_POLICY: 'nsfwDisplayPolicy',
   DEFAULT_RELAY_URLS: 'defaultRelayUrls',
   MUTED_WORDS: 'mutedWords',
+  MUTED_NIP05_DOMAINS: 'mutedNip05Domains',
   MIN_TRUST_SCORE: 'minTrustScore',
   MIN_TRUST_SCORE_MAP: 'minTrustScoreMap',
   SEARCH_RELAY_URLS: 'searchRelayUrls',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -668,6 +668,10 @@ export default {
     'Invalid relay URL': 'Invalid relay URL',
     'Muted words': 'Muted words',
     'Add muted word': 'Add muted word',
+    'Muted NIP-05 domains': 'Muted NIP-05 domains',
+    'Hide notes from these NIP-05 domains unless you follow the author':
+      'Hide notes from these NIP-05 domains unless you follow the author',
+    'Add NIP-05 domain': 'Add NIP-05 domain',
     'Zap Details': 'Zap Details',
     'Default trust score filter threshold ({{n}}%)':
       'Default trust score filter threshold ({{n}}%)',

--- a/src/lib/muted-nip05.spec.ts
+++ b/src/lib/muted-nip05.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getPubkeysMutedByNip05Domain,
+  isProfileMutedByNip05Domain,
+  normalizeMutedNip05Domains
+} from './muted-nip05'
+
+describe('muted NIP-05 domains', () => {
+  it('normalizes NIP-05 identifiers to lowercase domains', () => {
+    expect(
+      normalizeMutedNip05Domains([' Mostr.Pub ', '@Mostr.Pub/', 'alice@example.com'])
+    ).toEqual(['mostr.pub', 'example.com'])
+  })
+
+  it('matches profiles by their NIP-05 domain', () => {
+    expect(
+      isProfileMutedByNip05Domain(
+        { pubkey: 'pubkey1', nip05: 'alex_at_gleasonator.com@mostr.pub' },
+        new Set(['mostr.pub']),
+        new Set()
+      )
+    ).toBe(true)
+  })
+
+  it('does not mute followed profiles from a muted NIP-05 domain', () => {
+    expect(
+      isProfileMutedByNip05Domain(
+        { pubkey: 'followed', nip05: 'friend@mostr.pub' },
+        new Set(['mostr.pub']),
+        new Set(['followed'])
+      )
+    ).toBe(false)
+  })
+
+  it('resolves muted pubkeys without checking followed profiles', async () => {
+    const fetchProfile = vi.fn(async (pubkey: string) => ({
+      pubkey,
+      nip05: pubkey === 'bridge' ? 'bridge_user@mostr.pub' : 'user@example.com'
+    }))
+
+    const mutedPubkeys = await getPubkeysMutedByNip05Domain(
+      ['bridge', 'regular', 'followed'],
+      new Set(['mostr.pub']),
+      new Set(['followed']),
+      fetchProfile
+    )
+
+    expect(mutedPubkeys).toEqual(new Set(['bridge']))
+    expect(fetchProfile).toHaveBeenCalledWith('bridge')
+    expect(fetchProfile).toHaveBeenCalledWith('regular')
+    expect(fetchProfile).not.toHaveBeenCalledWith('followed')
+  })
+})

--- a/src/lib/muted-nip05.ts
+++ b/src/lib/muted-nip05.ts
@@ -1,0 +1,64 @@
+type TProfileWithNip05 = {
+  pubkey: string
+  nip05?: string | null
+}
+
+export function normalizeNip05Domain(value?: string | null) {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase().replace(/^@+/, '').replace(/\/+$/, '')
+  if (!normalized) return null
+
+  const domain = normalized.includes('@') ? normalized.split('@').pop() : normalized
+  return domain || null
+}
+
+export function normalizeMutedNip05Domains(values: string[]) {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeNip05Domain(value))
+        .filter((value): value is string => !!value)
+    )
+  )
+}
+
+export function isProfileMutedByNip05Domain(
+  profile: TProfileWithNip05 | null | undefined,
+  mutedNip05DomainSet: Set<string>,
+  followingSet: Set<string>
+) {
+  if (!profile || mutedNip05DomainSet.size === 0) return false
+  if (followingSet.has(profile.pubkey)) return false
+
+  const domain = normalizeNip05Domain(profile.nip05)
+  return !!domain && mutedNip05DomainSet.has(domain)
+}
+
+export async function getPubkeysMutedByNip05Domain(
+  pubkeys: string[],
+  mutedNip05DomainSet: Set<string>,
+  followingSet: Set<string>,
+  fetchProfile: (pubkey: string) => Promise<TProfileWithNip05 | null>
+) {
+  const mutedPubkeys = new Set<string>()
+  if (mutedNip05DomainSet.size === 0) return mutedPubkeys
+
+  const uniquePubkeys = Array.from(new Set(pubkeys)).filter((pubkey) => !followingSet.has(pubkey))
+  const results = await Promise.allSettled(
+    uniquePubkeys.map(async (pubkey) => ({
+      pubkey,
+      profile: await fetchProfile(pubkey)
+    }))
+  )
+
+  results.forEach((result) => {
+    if (result.status !== 'fulfilled') return
+    const { pubkey, profile } = result.value
+    if (isProfileMutedByNip05Domain(profile, mutedNip05DomainSet, followingSet)) {
+      mutedPubkeys.add(pubkey)
+    }
+  })
+
+  return mutedPubkeys
+}

--- a/src/pages/secondary/GeneralSettingsPage/MutedNip05Domains.tsx
+++ b/src/pages/secondary/GeneralSettingsPage/MutedNip05Domains.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { SettingsRow } from '@/components/ui/settings'
+import { normalizeNip05Domain } from '@/lib/muted-nip05'
+import { useContentPolicy } from '@/providers/ContentPolicyProvider'
+import { Plus, X } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export default function MutedNip05Domains() {
+  const { t } = useTranslation()
+  const { mutedNip05Domains, setMutedNip05Domains } = useContentPolicy()
+  const [newDomain, setNewDomain] = useState('')
+  const normalizedDomain = normalizeNip05Domain(newDomain)
+
+  const handleAddDomain = () => {
+    if (normalizedDomain && !mutedNip05Domains.includes(normalizedDomain)) {
+      setMutedNip05Domains([...mutedNip05Domains, normalizedDomain])
+      setNewDomain('')
+    }
+  }
+
+  const handleRemoveDomain = (domain: string) => {
+    setMutedNip05Domains(mutedNip05Domains.filter((d) => d !== domain))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleAddDomain()
+    }
+  }
+
+  return (
+    <SettingsRow
+      layout="stacked"
+      title={t('Muted NIP-05 domains')}
+      description={t('Hide notes from these NIP-05 domains unless you follow the author')}
+    >
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <Input
+            placeholder={t('Add NIP-05 domain')}
+            value={newDomain}
+            onChange={(e) => setNewDomain(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleAddDomain}
+            disabled={!normalizedDomain || mutedNip05Domains.includes(normalizedDomain)}
+          >
+            <Plus />
+          </Button>
+        </div>
+        {mutedNip05Domains.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {mutedNip05Domains.map((domain) => (
+              <div
+                key={domain}
+                className="flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
+              >
+                <span>{domain}</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-4 w-4 hover:bg-transparent"
+                  onClick={() => handleRemoveDomain(domain)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </SettingsRow>
+  )
+}

--- a/src/pages/secondary/GeneralSettingsPage/index.tsx
+++ b/src/pages/secondary/GeneralSettingsPage/index.tsx
@@ -21,6 +21,7 @@ import { RotateCcw } from 'lucide-react'
 import { forwardRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import DefaultTrustScoreFilter from './DefaultTrustScoreFilter'
+import MutedNip05Domains from './MutedNip05Domains'
 import MutedWords from './MutedWords'
 
 const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
@@ -151,6 +152,7 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
           />
           <DefaultTrustScoreFilter />
           <MutedWords />
+          <MutedNip05Domains />
         </SettingsGroup>
 
         <SettingsGroup title={t('Reactions')}>

--- a/src/providers/ContentPolicyProvider.tsx
+++ b/src/providers/ContentPolicyProvider.tsx
@@ -29,6 +29,9 @@ type TContentPolicyContext = {
 
   mutedWords: string[]
   setMutedWords: (words: string[]) => void
+
+  mutedNip05Domains: string[]
+  setMutedNip05Domains: (domains: string[]) => void
 }
 
 const ContentPolicyContext = createContext<TContentPolicyContext | undefined>(undefined)
@@ -54,6 +57,7 @@ export function ContentPolicyProvider({ children }: { children: React.ReactNode 
   )
   const [faviconUrlTemplate, setFaviconUrlTemplate] = useState(storage.getFaviconUrlTemplate())
   const [mutedWords, setMutedWords] = useState(storage.getMutedWords())
+  const [mutedNip05Domains, setMutedNip05Domains] = useState(storage.getMutedNip05Domains())
   const [connectionType, setConnectionType] = useState((navigator as any).connection?.type)
 
   useEffect(() => {
@@ -127,6 +131,11 @@ export function ContentPolicyProvider({ children }: { children: React.ReactNode 
     setMutedWords(words)
   }
 
+  const updateMutedNip05Domains = (domains: string[]) => {
+    storage.setMutedNip05Domains(domains)
+    setMutedNip05Domains(storage.getMutedNip05Domains())
+  }
+
   return (
     <ContentPolicyContext.Provider
       value={{
@@ -147,7 +156,9 @@ export function ContentPolicyProvider({ children }: { children: React.ReactNode 
         faviconUrlTemplate,
         setFaviconUrlTemplate: updateFaviconUrlTemplate,
         mutedWords,
-        setMutedWords: updateMutedWords
+        setMutedWords: updateMutedWords,
+        mutedNip05Domains,
+        setMutedNip05Domains: updateMutedNip05Domains
       }}
     >
       {children}

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -14,6 +14,7 @@ import {
   TPrimaryColor
 } from '@/constants'
 import { isSameAccount } from '@/lib/account'
+import { normalizeMutedNip05Domains } from '@/lib/muted-nip05'
 import { getElectronBridge, isElectron } from '@/lib/platform'
 import { randomString } from '@/lib/random'
 import { isTorBrowser } from '@/lib/utils'
@@ -74,6 +75,7 @@ class LocalStorageService {
   private defaultRelayUrls: string[] = BIG_RELAY_URLS
   private searchRelayUrls: string[] = SEARCHABLE_RELAY_URLS
   private mutedWords: string[] = []
+  private mutedNip05Domains: string[] = []
   private minTrustScore: number = 0
   private minTrustScoreMap: Record<string, number> = {}
   private hideIndirectNotifications: boolean = false
@@ -480,6 +482,18 @@ class LocalStorageService {
         const words = JSON.parse(mutedWordsStr)
         if (Array.isArray(words) && words.every((word) => typeof word === 'string')) {
           this.mutedWords = words
+        }
+      } catch {
+        // Invalid JSON, use default
+      }
+    }
+
+    const mutedNip05DomainsStr = window.localStorage.getItem(StorageKey.MUTED_NIP05_DOMAINS)
+    if (mutedNip05DomainsStr) {
+      try {
+        const domains = JSON.parse(mutedNip05DomainsStr)
+        if (Array.isArray(domains) && domains.every((domain) => typeof domain === 'string')) {
+          this.mutedNip05Domains = normalizeMutedNip05Domains(domains)
         }
       } catch {
         // Invalid JSON, use default
@@ -1111,6 +1125,18 @@ class LocalStorageService {
   setMutedWords(words: string[]) {
     this.mutedWords = words
     window.localStorage.setItem(StorageKey.MUTED_WORDS, JSON.stringify(this.mutedWords))
+  }
+
+  getMutedNip05Domains() {
+    return this.mutedNip05Domains
+  }
+
+  setMutedNip05Domains(domains: string[]) {
+    this.mutedNip05Domains = normalizeMutedNip05Domains(domains)
+    window.localStorage.setItem(
+      StorageKey.MUTED_NIP05_DOMAINS,
+      JSON.stringify(this.mutedNip05Domains)
+    )
   }
 
   getHideIndirectNotifications() {


### PR DESCRIPTION
## Summary
- add a General settings control for muted NIP-05 domains
- normalize NIP-05 identifiers/domains before storing them
- hide feed notes, repost targets, and user aggregation items from muted NIP-05 domains
- keep followed profiles visible even when their NIP-05 domain is muted

Fixes #149

## Verification
- `npm test`
- `npm run lint`
- `npm run build`

Note: `npm run build` prints existing warnings for `Invalid URL: wss://` and large chunks, but exits 0.