### PR TITLE
Add URL note search action

### DIFF
--- a/src/components/ExternalLink/index.tsx
+++ b/src/components/ExternalLink/index.tsx
@@ -7,11 +7,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { toExternalContent } from '@/lib/link'
+import { toExternalContent, toSearch } from '@/lib/link'
 import { truncateUrl } from '@/lib/url'
 import { cn } from '@/lib/utils'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
-import { ExternalLink as ExternalLinkIcon, MessageSquare } from 'lucide-react'
+import { ExternalLink as ExternalLinkIcon, MessageSquare, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -46,6 +46,17 @@ export default function ExternalLink({
       return
     }
     push(toExternalContent(url))
+  }
+
+  const handleSearchNotes = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const searchUrl = toSearch({ type: 'notes', search: url, input: url })
+    if (isSmallScreen) {
+      setIsDrawerOpen(false)
+      setTimeout(() => push(searchUrl), 100) // wait for drawer to close
+      return
+    }
+    push(searchUrl)
   }
 
   if (justOpenLink) {
@@ -106,6 +117,14 @@ export default function ExternalLink({
                 <MessageSquare />
                 {t('View Nostr discussions')}
               </Button>
+              <Button
+                onClick={handleSearchNotes}
+                className="w-full justify-start gap-4 p-6 text-lg [&_svg]:size-5"
+                variant="ghost"
+              >
+                <Search />
+                {t('Search for notes')}
+              </Button>
             </div>
           </DrawerContent>
         </Drawer>
@@ -128,6 +147,10 @@ export default function ExternalLink({
         <DropdownMenuItem onClick={handleViewDiscussions}>
           <MessageSquare />
           {t('View Nostr discussions')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleSearchNotes}>
+          <Search />
+          {t('Search for notes')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- add a third URL menu action that searches global notes for the clicked URL
- reuse the existing `/search?t=notes&q=...` flow so results use the normal note search feed
- keep the existing open-link and Nostr discussions actions unchanged

Refs #218. This implements the note-search part of the request; the follow/notify option can stay as a separate follow-up because it needs persistence/subscription behavior.

## Validation
- `pnpm exec eslint src/components/ExternalLink/index.tsx`
- `pnpm exec tsc -b --pretty false`
- `pnpm run build` reaches Vite after TypeScript, then fails in this Codex macOS environment because Rollup's native darwin-arm64 addon is blocked by code-signing/library-validation (`ERR_DLOPEN_FAILED`).