### PR TITLE
perf(note-list): virtualize with react-virtuoso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^15.7.4",
         "react-markdown": "^10.1.0",
+        "react-virtuoso": "^4.18.7",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -14718,6 +14719,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.7",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.7.tgz",
+      "integrity": "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/read-binary-file-arch": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^15.7.4",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.18.7",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/src/components/Embedded/EmbeddedNote.tsx
+++ b/src/components/Embedded/EmbeddedNote.tsx
@@ -2,38 +2,15 @@ import { UserAvatarSkeleton } from '@/components/UserAvatar'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useFetchEvent } from '@/hooks'
 import { cn } from '@/lib/utils'
-import { forwardRef, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ClientSelect from '../ClientSelect'
 import MainNoteCard from '../NoteCard/MainNoteCard'
 
 export function EmbeddedNote({ noteId, className }: { noteId: string; className?: string }) {
   const { event, isFetching } = useFetchEvent(noteId)
-  const skeletonRef = useRef<HTMLDivElement>(null)
-  const [revealed, setRevealed] = useState(false)
 
-  useEffect(() => {
-    if (revealed || isFetching) return
-    const el = skeletonRef.current
-    if (!el) return
-    // Only freeze skeleton if the element is above the viewport (already scrolled past).
-    // If it's in view or still below, reveal immediately so the user sees real content
-    // as they reach it.
-    if (el.getBoundingClientRect().bottom > 0) {
-      setRevealed(true)
-      return
-    }
-    const io = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setRevealed(true)
-      }
-    })
-    io.observe(el)
-    return () => io.disconnect()
-  }, [isFetching, revealed])
-
-  if (!revealed) {
-    return <EmbeddedNoteSkeleton ref={skeletonRef} className={className} />
+  if (isFetching) {
+    return <EmbeddedNoteSkeleton className={className} />
   }
 
   if (!event) {
@@ -50,28 +27,24 @@ export function EmbeddedNote({ noteId, className }: { noteId: string; className?
   )
 }
 
-const EmbeddedNoteSkeleton = forwardRef<HTMLDivElement, { className?: string }>(
-  ({ className }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={cn('w-full rounded-xl border bg-card p-2 text-start sm:p-3', className)}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center gap-2">
-          <UserAvatarSkeleton className="h-9 w-9" />
-          <div>
-            <Skeleton className="my-1 h-3 w-16" />
-            <Skeleton className="my-1 h-3 w-16" />
-          </div>
+function EmbeddedNoteSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn('w-full rounded-xl border bg-card p-2 text-start sm:p-3', className)}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center gap-2">
+        <UserAvatarSkeleton className="h-9 w-9" />
+        <div>
+          <Skeleton className="my-1 h-3 w-16" />
+          <Skeleton className="my-1 h-3 w-16" />
         </div>
-        <Skeleton className="my-1 mt-2 h-4 w-full" />
-        <Skeleton className="my-1 h-4 w-2/3" />
       </div>
-    )
-  }
-)
-EmbeddedNoteSkeleton.displayName = 'EmbeddedNoteSkeleton'
+      <Skeleton className="my-1 mt-2 h-4 w-full" />
+      <Skeleton className="my-1 h-4 w-2/3" />
+    </div>
+  )
+}
 
 function EmbeddedNoteNotFound({ noteId, className }: { noteId: string; className?: string }) {
   const { t } = useTranslation()

--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -1,7 +1,6 @@
 import NewNotesButton from '@/components/NewNotesButton'
 import { Button } from '@/components/ui/button'
 import { SPAMMER_PERCENTILE_THRESHOLD } from '@/constants'
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { getEventKey, getKeyFromTag, isMentioningMutedUsers, isReplyNoteEvent } from '@/lib/event'
 import { tagNameEquals } from '@/lib/tag'
 import { mergeTimelines } from '@/lib/timeline'
@@ -10,6 +9,7 @@ import { useDeletedEvent } from '@/providers/DeletedEventProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
 import { useNostr } from '@/providers/NostrProvider'
 import { usePageActive } from '@/providers/PageActiveProvider'
+import { useScrollArea } from '@/providers/ScrollAreaProvider'
 import { useUserTrust } from '@/providers/UserTrustProvider'
 import client from '@/services/client.service'
 import threadService from '@/services/thread.service'
@@ -22,20 +22,69 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import PullToRefresh from '../PullToRefresh'
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 import { toast } from 'sonner'
 import { LoadingBar } from '../LoadingBar'
 import NoteCard, { NoteCardLoadingSkeleton } from '../NoteCard'
 import PinnedNoteCard from '../PinnedNoteCard'
+import PullToRefresh from '../PullToRefresh'
 
 const LIMIT = 200
 const ALGO_LIMIT = 500
-const SHOW_COUNT = 10
+
+type TListItem =
+  | { kind: 'pinned'; id: string }
+  | { kind: 'note'; key: string; event: Event; reposters: string[] }
+
+type TVirtuosoContext = {
+  initialLoading: boolean
+  loadingMore: boolean
+  filtering: boolean
+  hasEvents: boolean
+  hasMore: boolean
+  onReload: () => void
+  filterMutedNotes: boolean
+}
+
+const VirtuosoHeader = ({ context }: { context?: TVirtuosoContext }) => {
+  if (!context) return null
+  return context.initialLoading && (context.hasMore || context.loadingMore) ? <LoadingBar /> : null
+}
+
+const VirtuosoFooter = ({ context }: { context?: TVirtuosoContext }) => {
+  const { t } = useTranslation()
+  if (!context) return null
+  if (context.loadingMore || context.filtering || context.initialLoading) {
+    return <NoteCardLoadingSkeleton />
+  }
+  if (context.hasEvents) {
+    return (
+      <div className="text-muted-foreground mt-2 text-center text-sm">{t('no more notes')}</div>
+    )
+  }
+  return (
+    <div className="mt-8 flex w-full flex-col items-center justify-center gap-4">
+      <div className="text-muted-foreground text-center">
+        <div className="text-lg font-medium">{t('No notes found')}</div>
+        <div className="mt-1 text-sm">{t('Try again later or check your connection')}</div>
+      </div>
+      <Button size="lg" onClick={context.onReload}>
+        {t('Reload')}
+      </Button>
+    </div>
+  )
+}
+
+const VIRTUOSO_COMPONENTS = {
+  Header: VirtuosoHeader,
+  Footer: VirtuosoFooter
+}
 
 export type TNoteListRef = {
   scrollToTop: (behavior?: ScrollBehavior) => void
@@ -78,7 +127,6 @@ const NoteList = forwardRef<
     },
     ref
   ) => {
-    const { t } = useTranslation()
     const active = usePageActive()
     const { startLogin } = useNostr()
     const { isSpammer, meetsMinTrustScore } = useUserTrust()
@@ -97,6 +145,7 @@ const NoteList = forwardRef<
     const [filteredNewEvents, setFilteredNewEvents] = useState<Event[]>([])
     const [refreshCount, setRefreshCount] = useState(0)
     const topRef = useRef<HTMLDivElement | null>(null)
+    const virtuosoRef = useRef<VirtuosoHandle | null>(null)
     const sinceRef = useRef<number | undefined>(undefined)
     sinceRef.current = newEvents.length
       ? newEvents[0].created_at + 1
@@ -464,11 +513,83 @@ const NoteList = forwardRef<
       return true
     }, [timelineKey, events, areAlgoRelays])
 
-    const { visibleItems, shouldShowLoadingIndicator, bottomRef } = useInfiniteScroll({
-      items: filteredNotes,
-      showCount: SHOW_COUNT,
-      onLoadMore: handleLoadMore,
-      initialLoading
+    const [hasMore, setHasMore] = useState(true)
+    const [loadingMore, setLoadingMore] = useState(false)
+
+    useEffect(() => {
+      // Reset pagination state whenever the underlying timeline is reset.
+      setHasMore(true)
+      setLoadingMore(false)
+    }, [JSON.stringify(subRequests), refreshCount])
+
+    const handleEndReached = useCallback(async () => {
+      if (loadingMore || !hasMore || areAlgoRelays || !timelineKey) return
+      setLoadingMore(true)
+      try {
+        const more = await handleLoadMore()
+        setHasMore(more)
+      } finally {
+        setLoadingMore(false)
+      }
+    }, [loadingMore, hasMore, areAlgoRelays, timelineKey, handleLoadMore])
+
+    const listItems = useMemo<TListItem[]>(() => {
+      const pinned: TListItem[] =
+        pinnedEventIds?.map((id) => ({ kind: 'pinned', id }) as const) ?? []
+      const notes: TListItem[] = filteredNotes.map(
+        ({ key, event, reposters }) => ({ kind: 'note', key, event, reposters }) as const
+      )
+      return [...pinned, ...notes]
+    }, [pinnedEventIds, filteredNotes])
+
+    const computeItemKey = useCallback(
+      (_index: number, item: TListItem) =>
+        item.kind === 'pinned' ? `pinned-${item.id}` : item.key,
+      []
+    )
+
+    const itemContent = useCallback(
+      (_index: number, item: TListItem) => {
+        if (item.kind === 'pinned') {
+          return <PinnedNoteCard eventId={item.id} className="w-full" />
+        }
+        return (
+          <NoteCard
+            className="w-full"
+            event={item.event}
+            filterMutedNotes={filterMutedNotes}
+            reposters={item.reposters}
+          />
+        )
+      },
+      [filterMutedNotes]
+    )
+
+    const onReload = useCallback(() => setRefreshCount((count) => count + 1), [])
+
+    const virtuosoContext = useMemo<TVirtuosoContext>(
+      () => ({
+        initialLoading,
+        loadingMore,
+        filtering,
+        hasEvents: events.length > 0,
+        hasMore,
+        onReload,
+        filterMutedNotes
+      }),
+      [initialLoading, loadingMore, filtering, events.length, hasMore, onReload, filterMutedNotes]
+    )
+
+    const { scrollAreaRef } = useScrollArea()
+    const useWindowScroll = !scrollAreaRef
+    const [customScrollParent, setCustomScrollParent] = useState<HTMLDivElement | null>(
+      () => scrollAreaRef?.current ?? null
+    )
+    useLayoutEffect(() => {
+      if (!scrollAreaRef) return
+      if (scrollAreaRef.current && scrollAreaRef.current !== customScrollParent) {
+        setCustomScrollParent(scrollAreaRef.current)
+      }
     })
 
     const showNewEvents = () => {
@@ -479,38 +600,6 @@ const NoteList = forwardRef<
       }, 0)
     }
 
-    const list = (
-      <div className="min-h-screen">
-        {initialLoading && shouldShowLoadingIndicator && <LoadingBar />}
-        {pinnedEventIds?.map((id) => <PinnedNoteCard key={id} eventId={id} className="w-full" />)}
-        {visibleItems.map(({ key, event, reposters }) => (
-          <NoteCard
-            key={key}
-            className="w-full"
-            event={event}
-            filterMutedNotes={filterMutedNotes}
-            reposters={reposters}
-          />
-        ))}
-        <div ref={bottomRef} />
-        {shouldShowLoadingIndicator || filtering || initialLoading ? (
-          <NoteCardLoadingSkeleton />
-        ) : events.length ? (
-          <div className="text-muted-foreground mt-2 text-center text-sm">{t('no more notes')}</div>
-        ) : (
-          <div className="mt-8 flex w-full flex-col items-center justify-center gap-4">
-            <div className="text-muted-foreground text-center">
-              <div className="text-lg font-medium">{t('No notes found')}</div>
-              <div className="mt-1 text-sm">{t('Try again later or check your connection')}</div>
-            </div>
-            <Button size="lg" onClick={() => setRefreshCount((count) => count + 1)}>
-              {t('Reload')}
-            </Button>
-          </div>
-        )}
-      </div>
-    )
-
     return (
       <div>
         <div ref={topRef} className="scroll-mt-24.25" />
@@ -520,7 +609,21 @@ const NoteList = forwardRef<
             await new Promise((resolve) => setTimeout(resolve, 1000))
           }}
         >
-          {list}
+          <Virtuoso
+            ref={virtuosoRef}
+            data={listItems}
+            itemContent={itemContent}
+            computeItemKey={computeItemKey}
+            components={VIRTUOSO_COMPONENTS}
+            context={virtuosoContext}
+            endReached={handleEndReached}
+            overscan={1000}
+            increaseViewportBy={1000}
+            skipAnimationFrameInResizeObserver
+            {...(useWindowScroll
+              ? { useWindowScroll: true }
+              : { customScrollParent: customScrollParent ?? undefined })}
+          />
         </PullToRefresh>
         <div className="h-20" />
         {filteredNewEvents.length > 0 && (

--- a/src/layouts/PrimaryPageLayout/index.tsx
+++ b/src/layouts/PrimaryPageLayout/index.tsx
@@ -6,6 +6,7 @@ import { usePrimaryPage } from '@/PageManager'
 import { DeepBrowsingProvider } from '@/providers/DeepBrowsingProvider'
 import { useNostr } from '@/providers/NostrProvider'
 import { PageActiveContext } from '@/providers/PageActiveProvider'
+import { ScrollAreaProvider } from '@/providers/ScrollAreaProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import { useUserPreferences } from '@/providers/UserPreferencesProvider'
 import { TPrimaryPageName } from '@/routes/primary'
@@ -165,16 +166,18 @@ const PrimaryPageLayout = forwardRef(
       return (
         <PageActiveContext.Provider value={current === pageName && display}>
           <DeepBrowsingProvider active={current === pageName && display}>
-            <div
-              ref={smallScreenScrollAreaRef}
-              style={{
-                paddingBottom: 'calc(env(safe-area-inset-bottom) + 3rem)'
-              }}
-            >
-              {resolvedTitlebar}
-              {children}
-            </div>
-            {displayScrollToTopButton && <ScrollToTopButton />}
+            <ScrollAreaProvider>
+              <div
+                ref={smallScreenScrollAreaRef}
+                style={{
+                  paddingBottom: 'calc(env(safe-area-inset-bottom) + 3rem)'
+                }}
+              >
+                {resolvedTitlebar}
+                {children}
+              </div>
+              {displayScrollToTopButton && <ScrollToTopButton />}
+            </ScrollAreaProvider>
           </DeepBrowsingProvider>
         </PageActiveContext.Provider>
       )
@@ -186,16 +189,18 @@ const PrimaryPageLayout = forwardRef(
           active={current === pageName && display}
           scrollAreaRef={scrollAreaRef}
         >
-          <ScrollArea
-            className="h-full overflow-auto"
-            scrollBarClassName="z-30 pt-12"
-            ref={scrollAreaRef}
-          >
-            {resolvedTitlebar}
-            {children}
-            <div className="h-4" />
-          </ScrollArea>
-          {displayScrollToTopButton && <ScrollToTopButton scrollAreaRef={scrollAreaRef} />}
+          <ScrollAreaProvider scrollAreaRef={scrollAreaRef}>
+            <ScrollArea
+              className="h-full overflow-auto"
+              scrollBarClassName="z-30 pt-12"
+              ref={scrollAreaRef}
+            >
+              {resolvedTitlebar}
+              {children}
+              <div className="h-4" />
+            </ScrollArea>
+            {displayScrollToTopButton && <ScrollToTopButton scrollAreaRef={scrollAreaRef} />}
+          </ScrollAreaProvider>
         </DeepBrowsingProvider>
       </PageActiveContext.Provider>
     )

--- a/src/layouts/SecondaryPageLayout/index.tsx
+++ b/src/layouts/SecondaryPageLayout/index.tsx
@@ -5,6 +5,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { useSecondaryPage } from '@/PageManager'
 import { DeepBrowsingProvider } from '@/providers/DeepBrowsingProvider'
 import { PageActiveContext } from '@/providers/PageActiveProvider'
+import { ScrollAreaProvider } from '@/providers/ScrollAreaProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import { useUserPreferences } from '@/providers/UserPreferencesProvider'
 import { ChevronLeft } from 'lucide-react'
@@ -101,16 +102,18 @@ const SecondaryPageLayout = forwardRef(
       return (
         <PageActiveContext.Provider value={currentIndex === index}>
           <DeepBrowsingProvider active={currentIndex === index}>
-            <div className="flex h-full flex-col">
-              <SecondaryPageTitlebar
-                title={title}
-                controls={controls}
-                hideBackButton={hideBackButton}
-                hideBottomBorder={hideTitlebarBottomBorder}
-                titlebar={titlebar}
-              />
-              <div className="flex min-h-0 flex-1 flex-col">{children}</div>
-            </div>
+            <ScrollAreaProvider>
+              <div className="flex h-full flex-col">
+                <SecondaryPageTitlebar
+                  title={title}
+                  controls={controls}
+                  hideBackButton={hideBackButton}
+                  hideBottomBorder={hideTitlebarBottomBorder}
+                  titlebar={titlebar}
+                />
+                <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+              </div>
+            </ScrollAreaProvider>
           </DeepBrowsingProvider>
         </PageActiveContext.Provider>
       )
@@ -119,22 +122,24 @@ const SecondaryPageLayout = forwardRef(
     return (
       <PageActiveContext.Provider value={currentIndex === index}>
         <DeepBrowsingProvider active={currentIndex === index} scrollAreaRef={scrollAreaRef}>
-          <ScrollArea
-            className="h-full overflow-auto"
-            scrollBarClassName="z-30 pt-12"
-            ref={scrollAreaRef}
-          >
-            <SecondaryPageTitlebar
-              title={title}
-              controls={controls}
-              hideBackButton={hideBackButton}
-              hideBottomBorder={hideTitlebarBottomBorder}
-              titlebar={titlebar}
-            />
-            {children}
-            <div className="h-4" />
-          </ScrollArea>
-          {displayScrollToTopButton && <ScrollToTopButton scrollAreaRef={scrollAreaRef} />}
+          <ScrollAreaProvider scrollAreaRef={scrollAreaRef}>
+            <ScrollArea
+              className="h-full overflow-auto"
+              scrollBarClassName="z-30 pt-12"
+              ref={scrollAreaRef}
+            >
+              <SecondaryPageTitlebar
+                title={title}
+                controls={controls}
+                hideBackButton={hideBackButton}
+                hideBottomBorder={hideTitlebarBottomBorder}
+                titlebar={titlebar}
+              />
+              {children}
+              <div className="h-4" />
+            </ScrollArea>
+            {displayScrollToTopButton && <ScrollToTopButton scrollAreaRef={scrollAreaRef} />}
+          </ScrollAreaProvider>
         </DeepBrowsingProvider>
       </PageActiveContext.Provider>
     )

--- a/src/providers/ScrollAreaProvider.tsx
+++ b/src/providers/ScrollAreaProvider.tsx
@@ -1,0 +1,21 @@
+import { createContext, ReactNode, RefObject, useContext } from 'react'
+
+type TScrollAreaContext = {
+  scrollAreaRef?: RefObject<HTMLDivElement>
+}
+
+const ScrollAreaContext = createContext<TScrollAreaContext>({})
+
+export const useScrollArea = () => useContext(ScrollAreaContext)
+
+export function ScrollAreaProvider({
+  scrollAreaRef,
+  children
+}: {
+  scrollAreaRef?: RefObject<HTMLDivElement>
+  children: ReactNode
+}) {
+  return (
+    <ScrollAreaContext.Provider value={{ scrollAreaRef }}>{children}</ScrollAreaContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace render-all-items + IntersectionObserver pagination in `NoteList` with `react-virtuoso`.
- Introduce `ScrollAreaProvider` so the list picks the right scroll mode: `useWindowScroll` on mobile (preserves the browser-chrome auto-hide behavior) vs `customScrollParent` on desktop (uses the existing Radix `ScrollArea` viewport).
- Tune Virtuoso with `overscan=1000`, `increaseViewportBy=1000`, and `skipAnimationFrameInResizeObserver` — keeps scroll-position compensation synchronous with size changes, eliminating the back-scroll jitter from variable-height items loading async (matches the config YakiHonne uses).
- Drop the `IntersectionObserver`-based reveal logic in `EmbeddedNote`; virtualization handles offscreen items now.

## Test plan
- [ ] Mobile: window scroll still hides browser chrome; pull-to-refresh works.
- [ ] Desktop: scrolling inside `PrimaryPageLayout` / `SecondaryPageLayout` is smooth.
- [ ] Initial load shows skeleton, then notes; reaching the bottom triggers pagination.
- [ ] Pinned notes appear above regular notes.
- [ ] `scrollToTop` & `refresh` imperative APIs still work.
- [ ] Switching primary pages no longer lags with thousands of notes loaded.
- [ ] Scrolling back up does not jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)