### PR TITLE
Add relay-set option to hide followed authors

### DIFF
--- a/src/__tests__/schemata-validation.spec.ts
+++ b/src/__tests__/schemata-validation.spec.ts
@@ -42,6 +42,7 @@ vi.mock('@/services/media-upload.service', () => ({
 
 // ── Imports ─────────────────────────────────────────────────────────────
 import { createRequire } from 'node:module'
+import path from 'node:path'
 import Ajv from 'ajv'
 import ajvErrors from 'ajv-errors'
 import { kinds, type Event } from 'nostr-tools'
@@ -73,9 +74,8 @@ import { ExtendedKind } from '@/constants'
 
 // ── Schema loading ──────────────────────────────────────────────────────
 const require_ = createRequire(import.meta.url)
-const schemataBase = require_
-  .resolve('@nostrability/schemata')
-  .replace(/\/dist\/.*/, '/dist/nips')
+const schemataPackageRoot = path.dirname(require_.resolve('@nostrability/schemata/package.json'))
+const schemataBase = path.join(schemataPackageRoot, 'dist', 'nips')
 
 function loadSchema(path: string): object {
   return require_(`${schemataBase}/${path}`)

--- a/src/components/NormalFeed/index.tsx
+++ b/src/components/NormalFeed/index.tsx
@@ -9,7 +9,7 @@ import { useKindFilter } from '@/providers/KindFilterProvider'
 import { useUserPreferences } from '@/providers/UserPreferencesProvider'
 import { useUserTrust } from '@/providers/UserTrustProvider'
 import { TFeedSubRequest, TFeedTabConfig } from '@/types'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import KindFilter from '../KindFilter'
 import { RefreshButton } from '../RefreshButton'
 
@@ -20,7 +20,9 @@ export default function NormalFeed({
   showRelayCloseReason = false,
   disable24hMode = false,
   onRefresh,
-  isPubkeyFeed = false
+  isPubkeyFeed = false,
+  hiddenAuthorPubkeys,
+  extraOptions
 }: {
   feedId: string
   subRequests: TFeedSubRequest[]
@@ -29,6 +31,8 @@ export default function NormalFeed({
   disable24hMode?: boolean
   onRefresh?: () => void
   isPubkeyFeed?: boolean
+  hiddenAuthorPubkeys?: ReadonlySet<string>
+  extraOptions?: ReactNode
 }) {
   const { getShowKinds } = useKindFilter()
   const { getMinTrustScore } = useUserTrust()
@@ -117,6 +121,7 @@ export default function NormalFeed({
             {showTrustScoreFilter && (
               <TrustScoreFilter filterId={feedId} onOpenChange={handleTrustFilterOpenChange} />
             )}
+            {extraOptions}
             {!subRequestsHaveKinds && !tabHasFixedKinds && (
               <KindFilter
                 feedId={feedId}
@@ -139,6 +144,7 @@ export default function NormalFeed({
             showRelayCloseReason={showRelayCloseReason}
             isPubkeyFeed={isPubkeyFeed}
             trustScoreThreshold={trustScoreThreshold}
+            hiddenAuthorPubkeys={hiddenAuthorPubkeys}
           />
         ) : (
           <NoteList
@@ -150,6 +156,7 @@ export default function NormalFeed({
             showRelayCloseReason={showRelayCloseReason}
             isPubkeyFeed={isPubkeyFeed}
             trustScoreThreshold={trustScoreThreshold}
+            hiddenAuthorPubkeys={hiddenAuthorPubkeys}
           />
         )
       ) : null}

--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { SPAMMER_PERCENTILE_THRESHOLD } from '@/constants'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { getEventKey, getKeyFromTag, isMentioningMutedUsers, isReplyNoteEvent } from '@/lib/event'
+import { isFollowedAuthor } from '@/lib/feed-filter'
 import { tagNameEquals } from '@/lib/tag'
 import { mergeTimelines } from '@/lib/timeline'
 import { useContentPolicy } from '@/providers/ContentPolicyProvider'
@@ -54,6 +55,7 @@ const NoteList = forwardRef<
     areAlgoRelays?: boolean
     showRelayCloseReason?: boolean
     pinnedEventIds?: string[]
+    hiddenAuthorPubkeys?: ReadonlySet<string>
     filterFn?: (event: Event) => boolean
     showNewNotesDirectly?: boolean
     isPubkeyFeed?: boolean
@@ -71,6 +73,7 @@ const NoteList = forwardRef<
       areAlgoRelays = false,
       showRelayCloseReason = false,
       pinnedEventIds,
+      hiddenAuthorPubkeys,
       filterFn,
       showNewNotesDirectly = false,
       isPubkeyFeed = false,
@@ -125,6 +128,7 @@ const NoteList = forwardRef<
       (evt: Event) => {
         if (pinnedEventHexIdSet.has(evt.id)) return true
         if (isEventDeleted(evt)) return true
+        if (isFollowedAuthor(evt, hiddenAuthorPubkeys)) return true
         if (filterMutedNotes && mutePubkeySet.has(evt.pubkey)) return true
         if (
           filterMutedNotes &&
@@ -147,7 +151,7 @@ const NoteList = forwardRef<
 
         return false
       },
-      [mutePubkeySet, isEventDeleted, filterFn, mutedWords, pinnedEventHexIdSet]
+      [mutePubkeySet, isEventDeleted, hiddenAuthorPubkeys, filterFn, mutedWords, pinnedEventHexIdSet]
     )
 
     useEffect(() => {

--- a/src/components/UserAggregationList/index.tsx
+++ b/src/components/UserAggregationList/index.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import UserAvatar, { SimpleUserAvatar, UserAvatarSkeleton } from '@/components/UserAvatar'
 import Username, { SimpleUsername } from '@/components/Username'
 import { isMentioningMutedUsers } from '@/lib/event'
+import { isFollowedAuthor } from '@/lib/feed-filter'
 import { toNote, toUserAggregationDetail } from '@/lib/link'
 import { mergeTimelines } from '@/lib/timeline'
 import { cn, isTouchDevice } from '@/lib/utils'
@@ -56,6 +57,7 @@ const UserAggregationList = forwardRef<
     showRelayCloseReason?: boolean
     isPubkeyFeed?: boolean
     trustScoreThreshold?: number
+    hiddenAuthorPubkeys?: ReadonlySet<string>
   }
 >(
   (
@@ -66,7 +68,8 @@ const UserAggregationList = forwardRef<
       areAlgoRelays = false,
       showRelayCloseReason = false,
       isPubkeyFeed = false,
-      trustScoreThreshold
+      trustScoreThreshold,
+      hiddenAuthorPubkeys
     },
     ref
   ) => {
@@ -275,6 +278,7 @@ const UserAggregationList = forwardRef<
             if (evt.pubkey === currentPubkey) return null
             if (evt.created_at < since) return null
             if (isEventDeleted(evt)) return null
+            if (isFollowedAuthor(evt, hiddenAuthorPubkeys)) return null
             if (filterMutedNotes && mutePubkeySet.has(evt.pubkey)) return null
             if (
               filterMutedNotes &&
@@ -300,6 +304,7 @@ const UserAggregationList = forwardRef<
       [
         mutePubkeySet,
         isEventDeleted,
+        hiddenAuthorPubkeys,
         currentPubkey,
         filterMutedNotes,
         hideContentMentioningMutedUsers,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const StorageKey = {
   MUTED_WORDS: 'mutedWords',
   MIN_TRUST_SCORE: 'minTrustScore',
   MIN_TRUST_SCORE_MAP: 'minTrustScoreMap',
+  HIDE_FOLLOWED_AUTHORS_FEED_MAP: 'hideFollowedAuthorsFeedMap',
   SEARCH_RELAY_URLS: 'searchRelayUrls',
   SEARCH_HISTORY: 'searchHistory',
   HIDE_INDIRECT_NOTIFICATIONS: 'hideIndirectNotifications',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export default {
     Profile: 'Profile',
     Logout: 'Logout',
     Following: 'Following',
+    'Hide followed authors': 'Hide followed authors',
     followings: 'followings',
     reposted: 'reposted',
     'just now': 'just now',

--- a/src/lib/feed-filter.spec.ts
+++ b/src/lib/feed-filter.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { Event } from 'nostr-tools'
+
+import { filterFollowedAuthors } from './feed-filter'
+
+function makeEvent(pubkey: string): Event {
+  return {
+    id: `${pubkey}0`.slice(0, 64).padEnd(64, '0'),
+    pubkey,
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: '',
+    sig: '0'.repeat(128)
+  }
+}
+
+describe('filterFollowedAuthors', () => {
+  it('keeps relay-set notes from unknown authors and removes notes from followed authors', () => {
+    const followedAuthor = '1'.repeat(64)
+    const unknownAuthor = '2'.repeat(64)
+
+    const result = filterFollowedAuthors(
+      [makeEvent(followedAuthor), makeEvent(unknownAuthor)],
+      new Set([followedAuthor])
+    )
+
+    expect(result.map((event) => event.pubkey)).toEqual([unknownAuthor])
+  })
+})

--- a/src/lib/feed-filter.ts
+++ b/src/lib/feed-filter.ts
@@ -1,0 +1,15 @@
+import { Event } from 'nostr-tools'
+
+export function isFollowedAuthor(
+  event: Event,
+  followedPubkeys: ReadonlySet<string> | undefined
+) {
+  return followedPubkeys?.has(event.pubkey) ?? false
+}
+
+export function filterFollowedAuthors(events: Event[], followedPubkeys: ReadonlySet<string>) {
+  if (followedPubkeys.size === 0) {
+    return events
+  }
+  return events.filter((event) => !isFollowedAuthor(event, followedPubkeys))
+}

--- a/src/pages/primary/NoteListPage/RelaysFeed.tsx
+++ b/src/pages/primary/NoteListPage/RelaysFeed.tsx
@@ -1,13 +1,22 @@
 import NormalFeed from '@/components/NormalFeed'
+import { Button } from '@/components/ui/button'
 import { checkAlgoRelay } from '@/lib/relay'
+import { cn } from '@/lib/utils'
 import { useFeed } from '@/providers/FeedProvider'
+import { useFollowList } from '@/providers/FollowListProvider'
 import relayInfoService from '@/services/relay-info.service'
+import storage from '@/services/local-storage.service'
+import { UserMinus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export default function RelaysFeed() {
+  const { t } = useTranslation()
   const { relayUrls, feedInfo } = useFeed()
+  const { followingSet } = useFollowList()
   const [isReady, setIsReady] = useState(false)
   const [areAlgoRelays, setAreAlgoRelays] = useState(false)
+  const [hideFollowedAuthors, setHideFollowedAuthors] = useState(false)
   const feedId = useMemo(() => {
     if (feedInfo?.feedType === 'relay' && feedInfo.id) {
       return `relay-${feedInfo.id}`
@@ -16,6 +25,10 @@ export default function RelaysFeed() {
     }
     return 'relays-default'
   }, [feedInfo])
+
+  useEffect(() => {
+    setHideFollowedAuthors(storage.getHideFollowedAuthorsForFeed(feedId))
+  }, [feedId])
 
   useEffect(() => {
     const init = async () => {
@@ -30,12 +43,36 @@ export default function RelaysFeed() {
     return null
   }
 
+  const hideFollowedAuthorsToggle =
+    followingSet.size > 0 ? (
+      <Button
+        variant="ghost"
+        size="titlebar-icon"
+        title={t('Hide followed authors')}
+        aria-label={t('Hide followed authors')}
+        className={cn(
+          hideFollowedAuthors
+            ? 'bg-muted/40 text-primary hover:text-primary-hover'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+        onClick={() => {
+          const nextValue = !hideFollowedAuthors
+          setHideFollowedAuthors(nextValue)
+          storage.setHideFollowedAuthorsForFeed(feedId, nextValue)
+        }}
+      >
+        <UserMinus size={16} />
+      </Button>
+    ) : null
+
   return (
     <NormalFeed
       feedId={feedId}
       subRequests={[{ urls: relayUrls, filter: {} }]}
       areAlgoRelays={areAlgoRelays}
       showRelayCloseReason
+      hiddenAuthorPubkeys={hideFollowedAuthors ? followingSet : undefined}
+      extraOptions={hideFollowedAuthorsToggle}
     />
   )
 }

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -77,6 +77,7 @@ class LocalStorageService {
   private mutedWords: string[] = []
   private minTrustScore: number = 0
   private minTrustScoreMap: Record<string, number> = {}
+  private hideFollowedAuthorsFeedMap: Record<string, boolean> = {}
   private hideIndirectNotifications: boolean = false
   private encryptionKeyPrivkeyMap: Record<string, string> = {}
   private clientKeyPrivkeyMap: Record<string, string> = {}
@@ -361,6 +362,20 @@ class LocalStorageService {
         const map = JSON.parse(minTrustScoreMapStr)
         if (typeof map === 'object' && map !== null) {
           this.minTrustScoreMap = map
+        }
+      } catch {
+        // Invalid JSON, use default
+      }
+    }
+
+    const hideFollowedAuthorsFeedMapStr = window.localStorage.getItem(
+      StorageKey.HIDE_FOLLOWED_AUTHORS_FEED_MAP
+    )
+    if (hideFollowedAuthorsFeedMapStr) {
+      try {
+        const map = JSON.parse(hideFollowedAuthorsFeedMapStr)
+        if (typeof map === 'object' && map !== null) {
+          this.hideFollowedAuthorsFeedMap = map
         }
       } catch {
         // Invalid JSON, use default
@@ -942,6 +957,24 @@ class LocalStorageService {
     const { [feedId]: _, ...rest } = this.showKindsMap
     this.showKindsMap = rest
     window.localStorage.setItem(StorageKey.SHOW_KINDS_MAP, JSON.stringify(this.showKindsMap))
+  }
+
+  getHideFollowedAuthorsForFeed(feedId: string): boolean {
+    return this.hideFollowedAuthorsFeedMap[feedId] ?? false
+  }
+
+  setHideFollowedAuthorsForFeed(feedId: string, hide: boolean) {
+    const nextMap = { ...this.hideFollowedAuthorsFeedMap }
+    if (hide) {
+      nextMap[feedId] = true
+    } else {
+      delete nextMap[feedId]
+    }
+    this.hideFollowedAuthorsFeedMap = nextMap
+    window.localStorage.setItem(
+      StorageKey.HIDE_FOLLOWED_AUTHORS_FEED_MAP,
+      JSON.stringify(nextMap)
+    )
   }
 
   getHideContentMentioningMutedUsers() {


### PR DESCRIPTION
Closes #157.

Lightning Bounties issue: https://app.lightningbounties.com/issue/dc34224d-d9d5-4f57-bdc4-bb5c5fed63da

## Summary
- Adds a relay-set feed option to hide notes from accounts in the current follow list.
- Persists the setting per relay/relay-set feed id.
- Applies the filter to both the normal note list and the 24h user aggregation view.
- Keeps the filter helper small and covered by a behavior test.
- Fixes Windows schema test path resolution so the full Vitest suite runs correctly on Windows.

## Validation
- npm test - 27 passed
- npm run lint
- npm run build

The focused src/lib/feed-filter.spec.ts test was run before implementation and failed because the helper did not exist yet; it passes with this patch.