### PR TITLE
fix(external-link): open in new tab on middle-click and ctrl/cmd-click

### DIFF
--- a/src/components/ExternalLink/index.tsx
+++ b/src/components/ExternalLink/index.tsx
@@ -30,12 +30,16 @@ export default function ExternalLink({
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const displayUrl = useMemo(() => truncateUrl(url), [url])
 
+  const openInNewTab = () => {
+    window.open(url, '_blank', 'noreferrer')
+  }
+
   const handleOpenLink = (e: React.MouseEvent) => {
     e.stopPropagation()
     if (isSmallScreen) {
       setIsDrawerOpen(false)
     }
-    window.open(url, '_blank', 'noreferrer')
+    openInNewTab()
   }
 
   const handleViewDiscussions = (e: React.MouseEvent) => {
@@ -62,13 +66,34 @@ export default function ExternalLink({
     )
   }
 
+  // Middle-click or ctrl/cmd+left-click should open the link directly in a new tab
+  // instead of showing the dropdown/drawer.
+  const isNewTabClick = (e: { button: number; ctrlKey: boolean; metaKey: boolean }) =>
+    e.button === 1 || (e.button === 0 && (e.ctrlKey || e.metaKey))
+
   const trigger = (
     <span
       className={cn('cursor-pointer text-primary hover:underline', className)}
+      onMouseDown={(e) => {
+        // Prevent the autoscroll cursor on middle-click
+        if (e.button === 1) e.preventDefault()
+      }}
       onClick={(e) => {
         e.stopPropagation()
+        if (e.ctrlKey || e.metaKey) {
+          e.preventDefault()
+          openInNewTab()
+          return
+        }
         if (isSmallScreen) {
           setIsDrawerOpen(true)
+        }
+      }}
+      onAuxClick={(e) => {
+        if (e.button === 1) {
+          e.preventDefault()
+          e.stopPropagation()
+          openInNewTab()
         }
       }}
       title={url}
@@ -109,7 +134,31 @@ export default function ExternalLink({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger
+        onPointerDown={(e) => {
+          if (isNewTabClick(e)) {
+            e.preventDefault()
+            e.stopPropagation()
+            openInNewTab()
+          }
+        }}
+        onMouseDown={(e) => {
+          // Prevent the autoscroll cursor on middle-click
+          if (e.button === 1) e.preventDefault()
+        }}
+        onClick={(e) => {
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault()
+            e.stopPropagation()
+          }
+        }}
+        onAuxClick={(e) => {
+          if (e.button === 1) {
+            e.preventDefault()
+            e.stopPropagation()
+          }
+        }}
+      >
         <span className={cn('cursor-pointer text-primary hover:underline', className)} title={url}>
           {displayUrl}
         </span>


### PR DESCRIPTION
Previously these clicks either showed the dropdown ("Open Link" / "View Nostr discussions") or did nothing. Now they bypass the menu and open the URL directly in a new tab, matching standard browser behavior.