### PR TITLE
feat(note): add expandable thread context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,20 +283,21 @@ Properties:
 
 ### src/components/ClickableCard
 
-A behavioral wrapper for any container whose `onClick` should navigate the user (e.g. note cards, reply cards, notification cards). It renders a `<div>` and forwards `HTMLAttributes<HTMLDivElement>`.
+A behavioral wrapper for a container whose `onClick` navigates the user (e.g. note cards, reply cards, notification cards). It renders a `<div>` and forwards `HTMLAttributes<HTMLDivElement>`.
 
-**Always use `ClickableCard` instead of a plain `<div onClick={...}>` when the container is meant to navigate on click.** It marks itself with `data-clickable-card` and filters the click before calling the provided `onClick`, so the handler only fires when the click is for *this* card. Specifically it skips:
+It marks itself with `data-clickable-card` and filters the click before calling the provided `onClick`, so the handler only fires when the click is for *this* card. Specifically it skips:
 
 1. Portal-rendered descendants (overlays, menus rendered outside the DOM subtree).
 2. Interactive controls inside the card — `button`, `a`, `input`, `textarea`, `select`, `[role="button"]` (matched via `closest()`).
-3. Clicks that originate inside a *nested* `ClickableCard` (e.g. an embedded note inside a note card, or a `StuffStats` action button — actions are real `<button>`s and are already covered by rule 2).
+3. Clicks that originate inside a *nested* `ClickableCard` (e.g. an embedded note inside a note card).
 
 **Why not just call `e.stopPropagation()` on inner controls?** React's `stopPropagation()` also calls `nativeEvent.stopPropagation()`, which prevents the click from bubbling to `document`. Radix Dialog/Drawer's touch-mode outside-click detection relies on that native bubble to close itself when the user taps outside. Stopping propagation breaks that detection. The filter-on-the-parent approach in `ClickableCard` sidesteps the issue entirely — clicks still bubble to `document`, we just ignore the ones that don't belong to us.
 
-**Rules for new components:**
+**When to use it:**
 
-- Any new card / row / list-item whose `onClick` navigates → wrap with `<ClickableCard>` instead of a plain `<div onClick={...}>`. Do not duplicate the filter logic by hand.
-- Inside such a card, custom clickable elements that are *not* a `button`/`a`/`input`/`textarea`/`select` must declare `role="button"` so the filter recognizes them. Do **not** rely on `e.stopPropagation()` to block the parent — it breaks Radix Dialog/Drawer touch-mode (see "Why not stopPropagation" above). If you need to handle the inner click *and* prevent the parent's navigation, the role/element-type alone is enough.
+- Use `<ClickableCard>` when the clickable container holds anything that could bubble an unwanted click — interactive controls (`<button>`, `<a>`, `StuffStats`, `NoteOptions`, etc.) or other clickable cards (e.g. embedded notes). For these cases, do **not** hand-roll the filter logic, and do **not** rely on `e.stopPropagation()` on inner controls (it breaks Radix Dialog/Drawer touch-mode — see above).
+- A plain `<div onClick={...}>` (or `<Card onClick={...}>`) is fine when the container only holds purely-display content (text, avatars, icons) with no clickable descendants. If you later add an interactive child or nested card, swap it for `<ClickableCard>` at that time.
+- Inside a `ClickableCard`, a custom clickable element that is *not* a `button`/`a`/`input`/`textarea`/`select` must declare `role="button"` so the filter recognizes it.
 - When introducing a brand-new kind of "clickable container" pattern (rare), keep the `data-clickable-card` contract consistent — i.e. extend `ClickableCard` or follow the same marker. Do not invent a parallel mechanism.
 
 ## Feature Documentation

--- a/src/components/NoteOptions/useMenuActions.tsx
+++ b/src/components/NoteOptions/useMenuActions.tsx
@@ -1,8 +1,14 @@
 import { formatError } from '@/lib/error'
-import { getNoteBech32Id, isProtectedEvent } from '@/lib/event'
+import {
+  getNoteBech32Id,
+  getReplaceableCoordinateFromEvent,
+  isProtectedEvent,
+  isReplaceableEvent
+} from '@/lib/event'
 import { toJumbleNote } from '@/lib/link'
 import { pubkeyToNpub } from '@/lib/pubkey'
 import { simplifyUrl } from '@/lib/url'
+import { useBookmarks } from '@/providers/BookmarksProvider'
 import { useCurrentRelays } from '@/providers/CurrentRelaysProvider'
 import { useFavoriteRelays } from '@/providers/FavoriteRelaysProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
@@ -12,6 +18,8 @@ import client from '@/services/client.service'
 import {
   Bell,
   BellOff,
+  Bookmark,
+  BookmarkX,
   Code,
   Copy,
   Link,
@@ -61,7 +69,7 @@ export function useMenuActions({
   isSmallScreen
 }: UseMenuActionsProps) {
   const { t } = useTranslation()
-  const { pubkey, attemptDelete } = useNostr()
+  const { pubkey, attemptDelete, bookmarkListEvent, checkLogin } = useNostr()
   const { relayUrls: currentBrowsingRelayUrls } = useCurrentRelays()
   const { relaySets, favoriteRelays } = useFavoriteRelays()
   const relayUrls = useMemo(() => {
@@ -69,7 +77,15 @@ export function useMenuActions({
   }, [currentBrowsingRelayUrls, favoriteRelays])
   const { mutePubkeyPublicly, mutePubkeyPrivately, unmutePubkey, mutePubkeySet } = useMuteList()
   const { pinnedEventHexIdSet, pin, unpin } = usePinList()
+  const { addBookmark, removeBookmark } = useBookmarks()
   const isMuted = useMemo(() => mutePubkeySet.has(event.pubkey), [mutePubkeySet, event])
+  const isBookmarked = useMemo(() => {
+    const isReplaceable = isReplaceableEvent(event.kind)
+    const eventKey = isReplaceable ? getReplaceableCoordinateFromEvent(event) : event.id
+    return !!bookmarkListEvent?.tags.some((tag) =>
+      isReplaceable ? tag[0] === 'a' && tag[1] === eventKey : tag[0] === 'e' && tag[1] === eventKey
+    )
+  }, [bookmarkListEvent, event])
 
   const broadcastSubMenu: SubMenuAction[] = useMemo(() => {
     const items = []
@@ -206,6 +222,24 @@ export function useMenuActions({
       }
     ]
 
+    if (pubkey) {
+      actions.push({
+        icon: isBookmarked ? BookmarkX : Bookmark,
+        label: isBookmarked ? t('Remove bookmark') : t('Bookmark'),
+        onClick: () => {
+          closeDrawer()
+          checkLogin(async () => {
+            if (isBookmarked) {
+              await removeBookmark(event)
+            } else {
+              await addBookmark(event)
+            }
+          })
+        },
+        separator: true
+      })
+    }
+
     const isProtected = isProtectedEvent(event)
     if (!isProtected || event.pubkey === pubkey) {
       actions.push({
@@ -300,6 +334,7 @@ export function useMenuActions({
     event,
     pubkey,
     isMuted,
+    isBookmarked,
     isSmallScreen,
     broadcastSubMenu,
     pinnedEventHexIdSet,
@@ -308,7 +343,10 @@ export function useMenuActions({
     setIsRawEventDialogOpen,
     mutePubkeyPrivately,
     mutePubkeyPublicly,
-    unmutePubkey
+    unmutePubkey,
+    checkLogin,
+    addBookmark,
+    removeBookmark
   ])
 
   return menuActions

--- a/src/components/ReplyNote/index.tsx
+++ b/src/components/ReplyNote/index.tsx
@@ -112,7 +112,7 @@ export default function ReplyNote({
         (autoLoadProfilePicture ? (
           <div className="bg-border absolute inset-s-8.25 top-14 bottom-0 z-20 w-0.5" />
         ) : (
-          <div className="absolute inset-s-2 top-5 bottom-0 z-20 w-3 rounded-ss-lg border-s border-t" />
+          <div className="absolute inset-s-2 top-5 bottom-0 z-20 w-3 rounded-ss-lg border-s-2 border-t-2" />
         ))}
       <Collapsible>
         <div

--- a/src/components/ReplyNote/index.tsx
+++ b/src/components/ReplyNote/index.tsx
@@ -110,7 +110,7 @@ export default function ReplyNote({
       {hasReplies &&
         !hideThreadGuide &&
         (autoLoadProfilePicture ? (
-          <div className="absolute inset-s-8.5 top-14 bottom-0 z-20 border-s" />
+          <div className="bg-border absolute inset-s-8.25 top-14 bottom-0 z-20 w-0.5" />
         ) : (
           <div className="absolute inset-s-2 top-5 bottom-0 z-20 w-3 rounded-ss-lg border-s border-t" />
         ))}

--- a/src/components/ReplyNoteList/SubReplies.tsx
+++ b/src/components/ReplyNoteList/SubReplies.tsx
@@ -50,14 +50,14 @@ export default function SubReplies({ parentKey }: { parentKey: string }) {
             setIsExpanded(!isExpanded)
           }}
           className={cn(
-            'clickable relative flex w-full items-center gap-1.5 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground',
+            'clickable text-muted-foreground hover:text-foreground relative flex w-full items-center gap-1.5 py-2 text-sm transition-colors',
             autoLoadProfilePicture ? 'ps-14' : 'ps-5'
           )}
         >
           <div
             className={cn(
-              'absolute bottom-0 top-0 z-20 w-px text-border',
-              autoLoadProfilePicture ? 'start-[34px]' : 'start-2'
+              'text-border absolute top-0 bottom-0 z-20 w-0.5',
+              autoLoadProfilePicture ? 'inset-s-8.25' : 'inset-s-2'
             )}
             style={{
               background: isExpanded
@@ -98,16 +98,17 @@ export default function SubReplies({ parentKey }: { parentKey: string }) {
               >
                 <div
                   className={cn(
-                    'absolute top-0 z-20 rounded-es-lg border-b border-s',
-                    autoLoadProfilePicture ? 'h-8' : 'h-6',
-                    autoLoadProfilePicture ? 'start-[34px] w-4' : 'start-2 w-7'
+                    'absolute top-0 z-20 rounded-es-lg border-s-2 border-b-2',
+                    autoLoadProfilePicture ? 'h-7.75' : 'h-6',
+                    autoLoadProfilePicture ? 'inset-s-8.25 w-4' : 'inset-s-2 w-7'
                   )}
                 />
                 {index < replies.length - 1 && (
                   <div
                     className={cn(
-                      'absolute bottom-0 z-20 border-s',
-                      autoLoadProfilePicture ? 'start-[34px]' : 'start-2', 'top-0'
+                      'bg-border absolute bottom-0 z-20 w-0.5',
+                      autoLoadProfilePicture ? 'inset-s-8.25' : 'inset-s-2',
+                      'top-0'
                     )}
                   />
                 )}

--- a/src/components/StuffStats/index.tsx
+++ b/src/components/StuffStats/index.tsx
@@ -5,7 +5,6 @@ import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import stuffStatsService from '@/services/stuff-stats.service'
 import { Event } from 'nostr-tools'
 import { useEffect, useState } from 'react'
-import BookmarkButton from '../BookmarkButton'
 import LikeButton from './LikeButton'
 import Likes from './Likes'
 import ReplyButton from './ReplyButton'
@@ -70,7 +69,6 @@ export default function StuffStats({
           <RepostButton stuff={stuff} />
           <LikeButton stuff={stuff} />
           <ZapButton stuff={stuff} />
-          <BookmarkButton stuff={stuff} />
           <SeenOnButton stuff={stuff} />
         </div>
       </div>
@@ -101,7 +99,6 @@ export default function StuffStats({
           <ZapButton stuff={stuff} />
         </div>
         <div className="flex items-center">
-          <BookmarkButton stuff={stuff} />
           <SeenOnButton stuff={stuff} />
         </div>
       </div>

--- a/src/components/StuffStats/index.tsx
+++ b/src/components/StuffStats/index.tsx
@@ -5,6 +5,7 @@ import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import stuffStatsService from '@/services/stuff-stats.service'
 import { Event } from 'nostr-tools'
 import { useEffect, useState } from 'react'
+import BookmarkButton from '../BookmarkButton'
 import LikeButton from './LikeButton'
 import Likes from './Likes'
 import ReplyButton from './ReplyButton'
@@ -99,6 +100,7 @@ export default function StuffStats({
           <ZapButton stuff={stuff} />
         </div>
         <div className="flex items-center">
+          <BookmarkButton stuff={stuff} />
           <SeenOnButton stuff={stuff} />
         </div>
       </div>

--- a/src/hooks/useThread.tsx
+++ b/src/hooks/useThread.tsx
@@ -1,6 +1,8 @@
 import threadService from '@/services/thread.service'
 import { useSyncExternalStore } from 'react'
 
+const NOOP = () => {}
+
 export function useThread(stuffKey: string) {
   return useSyncExternalStore(
     (cb) => threadService.listenThread(stuffKey, cb),
@@ -12,5 +14,12 @@ export function useAllDescendantThreads(stuffKey: string) {
   return useSyncExternalStore(
     (cb) => threadService.listenAllDescendantThreads(stuffKey, cb),
     () => threadService.getAllDescendantThreads(stuffKey)
+  )
+}
+
+export function useAncestorChain(currentKey: string, rootKey: string) {
+  return useSyncExternalStore(
+    (cb) => (rootKey ? threadService.listenAllDescendantThreads(rootKey, cb) : NOOP),
+    () => threadService.getAncestorChain(currentKey, rootKey)
   )
 }

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -971,6 +971,8 @@ export default {
     'End date': 'تاريخ الانتهاء',
     'Advanced options': 'خيارات متقدمة',
     'Polls may not display on clients that don’t support them.':
-      'قد لا تظهر الاستطلاعات على العملاء الذين لا يدعمونها.'
+      'قد لا تظهر الاستطلاعات على العملاء الذين لا يدعمونها.',
+    'Show thread context': 'إظهار سياق المحادثة',
+    'Hide thread context': 'إخفاء سياق المحادثة'
   }
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1003,6 +1003,8 @@ export default {
     'End date': 'Enddatum',
     'Advanced options': 'Erweiterte Optionen',
     'Polls may not display on clients that don’t support them.':
-      'Umfragen werden möglicherweise nicht auf Clients angezeigt, die sie nicht unterstützen.'
+      'Umfragen werden möglicherweise nicht auf Clients angezeigt, die sie nicht unterstützen.',
+    'Show thread context': 'Thread-Kontext anzeigen',
+    'Hide thread context': 'Thread-Kontext ausblenden'
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1005,6 +1005,8 @@ export default {
     'End date': 'End date',
     'Advanced options': 'Advanced options',
     'Polls may not display on clients that don’t support them.':
-      'Polls may not display on clients that don’t support them.'
+      'Polls may not display on clients that don’t support them.',
+    'Show thread context': 'Show thread context',
+    'Hide thread context': 'Hide thread context'
   }
 }

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -992,6 +992,8 @@ export default {
     'End date': 'Fecha de finalización',
     'Advanced options': 'Opciones avanzadas',
     'Polls may not display on clients that don’t support them.':
-      'Es posible que las encuestas no se muestren en clientes que no las admiten.'
+      'Es posible que las encuestas no se muestren en clientes que no las admiten.',
+    'Show thread context': 'Mostrar contexto del hilo',
+    'Hide thread context': 'Ocultar contexto del hilo'
   }
 }

--- a/src/i18n/locales/fa.ts
+++ b/src/i18n/locales/fa.ts
@@ -987,6 +987,8 @@ export default {
     'End date': 'تاریخ پایان',
     'Advanced options': 'گزینه‌های پیشرفته',
     'Polls may not display on clients that don’t support them.':
-      'نظرسنجی‌ها ممکن است در کلاینت‌هایی که از آن‌ها پشتیبانی نمی‌کنند نمایش داده نشوند.'
+      'نظرسنجی‌ها ممکن است در کلاینت‌هایی که از آن‌ها پشتیبانی نمی‌کنند نمایش داده نشوند.',
+    'Show thread context': 'نمایش بافت گفت‌وگو',
+    'Hide thread context': 'پنهان کردن بافت گفت‌وگو'
   }
 }

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1001,6 +1001,8 @@ export default {
     'End date': 'Date de fin',
     'Advanced options': 'Options avancées',
     'Polls may not display on clients that don’t support them.':
-      'Les sondages peuvent ne pas s’afficher sur les clients qui ne les prennent pas en charge.'
+      'Les sondages peuvent ne pas s’afficher sur les clients qui ne les prennent pas en charge.',
+    'Show thread context': 'Afficher le contexte du fil',
+    'Hide thread context': 'Masquer le contexte du fil'
   }
 }

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -987,6 +987,8 @@ export default {
     'End date': 'समाप्ति तिथि',
     'Advanced options': 'उन्नत विकल्प',
     'Polls may not display on clients that don’t support them.':
-      'पोल उन क्लाइंट पर प्रदर्शित नहीं हो सकते जो इनका समर्थन नहीं करते।'
+      'पोल उन क्लाइंट पर प्रदर्शित नहीं हो सकते जो इनका समर्थन नहीं करते।',
+    'Show thread context': 'थ्रेड संदर्भ दिखाएं',
+    'Hide thread context': 'थ्रेड संदर्भ छिपाएं'
   }
 }

--- a/src/i18n/locales/hu.ts
+++ b/src/i18n/locales/hu.ts
@@ -987,6 +987,8 @@ export default {
     'End date': 'Befejezés dátuma',
     'Advanced options': 'Speciális beállítások',
     'Polls may not display on clients that don’t support them.':
-      'A szavazások előfordulhat, hogy nem jelennek meg azokon a klienseken, amelyek nem támogatják őket.'
+      'A szavazások előfordulhat, hogy nem jelennek meg azokon a klienseken, amelyek nem támogatják őket.',
+    'Show thread context': 'Beszélgetés kontextusának megjelenítése',
+    'Hide thread context': 'Beszélgetés kontextusának elrejtése'
   }
 }

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -992,6 +992,8 @@ export default {
     'End date': 'Data di fine',
     'Advanced options': 'Opzioni avanzate',
     'Polls may not display on clients that don’t support them.':
-      'I sondaggi potrebbero non essere visualizzati sui client che non li supportano.'
+      'I sondaggi potrebbero non essere visualizzati sui client che non li supportano.',
+    'Show thread context': 'Mostra contesto del thread',
+    'Hide thread context': 'Nascondi contesto del thread'
   }
 }

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -988,6 +988,8 @@ export default {
     'End date': '終了日',
     'Advanced options': '詳細オプション',
     'Polls may not display on clients that don’t support them.':
-      '投票機能に対応していないクライアントでは表示されない場合があります。'
+      '投票機能に対応していないクライアントでは表示されない場合があります。',
+    'Show thread context': 'スレッドの文脈を表示',
+    'Hide thread context': 'スレッドの文脈を非表示'
   }
 }

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -977,6 +977,8 @@ export default {
     'End date': '종료 날짜',
     'Advanced options': '고급 옵션',
     'Polls may not display on clients that don’t support them.':
-      '투표를 지원하지 않는 클라이언트에서는 표시되지 않을 수 있습니다.'
+      '투표를 지원하지 않는 클라이언트에서는 표시되지 않을 수 있습니다.',
+    'Show thread context': '스레드 맥락 보기',
+    'Hide thread context': '스레드 맥락 숨기기'
   }
 }

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -995,6 +995,8 @@ export default {
     'End date': 'Data zakończenia',
     'Advanced options': 'Opcje zaawansowane',
     'Polls may not display on clients that don’t support them.':
-      'Ankiety mogą nie być wyświetlane w klientach, które ich nie obsługują.'
+      'Ankiety mogą nie być wyświetlane w klientach, które ich nie obsługują.',
+    'Show thread context': 'Pokaż kontekst wątku',
+    'Hide thread context': 'Ukryj kontekst wątku'
   }
 }

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -991,6 +991,8 @@ export default {
     'End date': 'Data final',
     'Advanced options': 'Opções avançadas',
     'Polls may not display on clients that don’t support them.':
-      'As enquetes podem não ser exibidas em clientes que não as suportam.'
+      'As enquetes podem não ser exibidas em clientes que não as suportam.',
+    'Show thread context': 'Mostrar contexto da conversa',
+    'Hide thread context': 'Ocultar contexto da conversa'
   }
 }

--- a/src/i18n/locales/pt-PT.ts
+++ b/src/i18n/locales/pt-PT.ts
@@ -994,6 +994,8 @@ export default {
     'End date': 'Data de fim',
     'Advanced options': 'Opções avançadas',
     'Polls may not display on clients that don’t support them.':
-      'As sondagens podem não ser apresentadas em clientes que não as suportem.'
+      'As sondagens podem não ser apresentadas em clientes que não as suportem.',
+    'Show thread context': 'Mostrar contexto da conversa',
+    'Hide thread context': 'Ocultar contexto da conversa'
   }
 }

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -993,6 +993,8 @@ export default {
     'End date': 'Дата окончания',
     'Advanced options': 'Дополнительные параметры',
     'Polls may not display on clients that don’t support them.':
-      'Опросы могут не отображаться в клиентах, которые их не поддерживают.'
+      'Опросы могут не отображаться в клиентах, которые их не поддерживают.',
+    'Show thread context': 'Показать контекст треда',
+    'Hide thread context': 'Скрыть контекст треда'
   }
 }

--- a/src/i18n/locales/th.ts
+++ b/src/i18n/locales/th.ts
@@ -970,6 +970,8 @@ export default {
     'End date': 'วันที่สิ้นสุด',
     'Advanced options': 'ตัวเลือกขั้นสูง',
     'Polls may not display on clients that don’t support them.':
-      'โพลอาจไม่แสดงบนไคลเอนต์ที่ไม่รองรับ'
+      'โพลอาจไม่แสดงบนไคลเอนต์ที่ไม่รองรับ',
+    'Show thread context': 'แสดงบริบทของเธรด',
+    'Hide thread context': 'ซ่อนบริบทของเธรด'
   }
 }

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -993,6 +993,8 @@ export default {
     'End date': 'Bitiş tarihi',
     'Advanced options': 'Gelişmiş seçenekler',
     'Polls may not display on clients that don’t support them.':
-      'Anketler, onları desteklemeyen istemcilerde görüntülenmeyebilir.'
+      'Anketler, onları desteklemeyen istemcilerde görüntülenmeyebilir.',
+    'Show thread context': 'Konu bağlamını göster',
+    'Hide thread context': 'Konu bağlamını gizle'
   }
 }

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -947,6 +947,8 @@ export default {
     'End date': '結束日期',
     'Advanced options': '進階選項',
     'Polls may not display on clients that don’t support them.':
-      '不支援投票的客戶端可能無法顯示此投票。'
+      '不支援投票的客戶端可能無法顯示此投票。',
+    'Show thread context': '展開對話上下文',
+    'Hide thread context': '收起對話上下文'
   }
 }

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -954,6 +954,8 @@ export default {
     'End date': '结束日期',
     'Advanced options': '高级选项',
     'Polls may not display on clients that don’t support them.':
-      '不支持投票的客户端可能无法显示此投票。'
+      '不支持投票的客户端可能无法显示此投票。',
+    'Show thread context': '展开对话上下文',
+    'Hide thread context': '收起对话上下文'
   }
 }

--- a/src/layouts/SecondaryPageLayout/index.tsx
+++ b/src/layouts/SecondaryPageLayout/index.tsx
@@ -44,12 +44,18 @@ const SecondaryPageLayout = forwardRef(
       ref,
       () => ({
         scrollToTop: (behavior: ScrollBehavior = 'smooth') => {
-          setTimeout(() => {
-            if (scrollAreaRef.current) {
-              return scrollAreaRef.current.scrollTo({ top: 0, behavior })
-            }
-            window.scrollTo({ top: 0, behavior })
-          }, 10)
+          // Double rAF: wait for React commit + next paint, so the scroll
+          // lands on the new layout and isn't fighting Safari's clamp /
+          // momentum scrolling when content height changes.
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              if (scrollAreaRef.current) {
+                scrollAreaRef.current.scrollTo({ top: 0, behavior })
+                return
+              }
+              window.scrollTo({ top: 0, behavior })
+            })
+          })
         }
       }),
       []

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -1,4 +1,5 @@
 import { useSecondaryPage } from '@/PageManager'
+import ClickableCard from '@/components/ClickableCard'
 import ClientTag from '@/components/ClientTag'
 import Content from '@/components/Content'
 import ContentPreview from '@/components/ContentPreview'
@@ -49,8 +50,6 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import NotFound from './NotFound'
-
-const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"]'
 
 const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, index }, ref) => {
   const { t } = useTranslation()
@@ -318,17 +317,12 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
   const { autoLoadProfilePicture } = useContentPolicy()
 
   return (
-    <div
+    <ClickableCard
       className={cn(
         'clickable hover:bg-accent/30 relative px-4 py-3 transition-colors duration-200',
         !autoLoadProfilePicture && 'border-b'
       )}
-      onClick={(e) => {
-        const target = e.target
-        if (!(target instanceof Node) || !e.currentTarget.contains(target)) return
-        if (target instanceof Element && target.closest(INTERACTIVE_SELECTOR)) return
-        push(toNote(event))
-      }}
+      onClick={() => push(toNote(event))}
     >
       {autoLoadProfilePicture && !isFirst && (
         <div className="bg-border absolute inset-s-8.75 top-0 z-0 h-2 w-0.5" />
@@ -370,7 +364,7 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
           <StuffStats className="mt-2" stuff={event} />
         </div>
       </div>
-    </div>
+    </ClickableCard>
   )
 }
 

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -69,21 +69,14 @@ const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, in
   const ancestorChain = useAncestorChain(currentKey, rootKey)
   const canExpand = !!parentEventId
   const fullChain = useMemo(() => {
-    const items: Event[] = []
-    const seen = new Set<string>()
-    if (rootEvent && rootEventId && rootEventId !== parentEventId) {
-      items.push(rootEvent)
-      seen.add(rootEvent.id)
+    const chain = [...ancestorChain]
+    if (rootEvent && chain[0] !== rootEvent.id) {
+      chain.unshift(rootEvent.id)
     }
-    for (const evt of ancestorChain) {
-      if (seen.has(evt.id)) continue
-      items.push(evt)
-      seen.add(evt.id)
+    if (parentEvent && chain[chain.length - 1] !== parentEvent.id) {
+      chain.push(parentEvent.id)
     }
-    if (parentEvent && !seen.has(parentEvent.id)) {
-      items.push(parentEvent)
-    }
-    return items
+    return chain
   }, [rootEvent, rootEventId, parentEvent, parentEventId, ancestorChain])
   const layoutRef = useRef<TPageRef>(null)
 
@@ -163,12 +156,8 @@ const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, in
           </div>
         )}
         {expanded
-          ? fullChain.map((ancestor, idx) => (
-              <ChainItem
-                key={`chain-${ancestor.id}`}
-                event={ancestor}
-                isFirst={idx === 0 && !rootITag}
-              />
+          ? fullChain.map((id, idx) => (
+              <ChainItem key={`chain-${id}`} eventId={id} isFirst={idx === 0 && !rootITag} />
             ))
           : canExpand && (
               <div className={cn('px-4', !rootITag && 'pt-3')}>
@@ -311,10 +300,18 @@ function isConsecutive(rootEvent?: Event, parentEvent?: Event) {
   return getEventKey(rootEvent) === getKeyFromTag(tag.tag)
 }
 
-function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
+function ChainItem({ eventId, isFirst }: { eventId: string; isFirst: boolean }) {
   const { push } = useSecondaryPage()
   const { isSmallScreen } = useScreenSize()
   const { autoLoadProfilePicture } = useContentPolicy()
+  const { event, isFetching } = useFetchEvent(eventId)
+
+  if (isFetching) {
+    return <ChainItemSkeleton isFirst={isFirst} />
+  }
+  if (!event) {
+    return null
+  }
 
   return (
     <ClickableCard
@@ -365,6 +362,36 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
         </div>
       </div>
     </ClickableCard>
+  )
+}
+
+function ChainItemSkeleton({ isFirst }: { isFirst: boolean }) {
+  const { autoLoadProfilePicture } = useContentPolicy()
+
+  return (
+    <div className={cn('relative px-4 py-3', !autoLoadProfilePicture && 'border-b')}>
+      {autoLoadProfilePicture && !isFirst && (
+        <div className="bg-border absolute inset-s-8.75 top-0 z-0 h-2 w-0.5" />
+      )}
+      {autoLoadProfilePicture && (
+        <div className="bg-border absolute inset-s-8.75 top-14.5 bottom-0 z-0 w-0.5" />
+      )}
+      <div className="flex items-start gap-2">
+        <UserAvatarSkeleton className="h-10 w-10" />
+        <div className="w-0 flex-1">
+          <div className="py-1">
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <div className="py-0.5">
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <div className="space-y-2 pt-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -41,6 +41,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
@@ -94,12 +95,16 @@ const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, in
   )
 
   const handleToggleExpand = useCallback(() => {
-    setExpanded((prev) => {
-      const next = !prev
-      if (!next) layoutRef.current?.scrollToTop('instant')
-      return next
-    })
+    setExpanded((prev) => !prev)
   }, [])
+
+  const prevExpandedRef = useRef(expanded)
+  useLayoutEffect(() => {
+    if (prevExpandedRef.current && !expanded) {
+      layoutRef.current?.scrollToTop('instant')
+    }
+    prevExpandedRef.current = expanded
+  }, [expanded])
 
   useEffect(() => {
     if (!expanded || !event) return

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -189,7 +189,7 @@ const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, in
                     noConnector
                   />
                 )}
-                <div className="bg-border ms-5 h-1 w-px" />
+                <div className="bg-border ms-4.75 h-1.5 w-0.5" />
               </div>
             )}
         {canExpand && <ExpandThreadButton expanded={expanded} onToggle={handleToggleExpand} />}
@@ -259,7 +259,7 @@ function ParentNote({
             <Skeleton className="h-3" />
           </div>
         </div>
-        {!noConnector && <div className="bg-border ms-5 h-3 w-px" />}
+        {!noConnector && <div className="bg-border ms-4.75 h-3 w-0.5" />}
       </div>
     )
   }
@@ -280,7 +280,7 @@ function ParentNote({
       </div>
       {!noConnector &&
         (isConsecutive ? (
-          <div className="bg-border ms-5 h-3 w-px" />
+          <div className="bg-border ms-4.75 h-3 w-0.5" />
         ) : (
           <Ellipsis className="text-muted-foreground/60 ms-3.5 size-3" />
         ))}
@@ -311,12 +311,8 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
         push(toNote(event))
       }}
     >
-      <div
-        className={cn(
-          'bg-border absolute inset-s-9 bottom-0 z-0 w-px',
-          isFirst ? 'top-15' : 'top-0'
-        )}
-      />
+      {!isFirst && <div className="bg-border absolute inset-s-8.75 top-0 z-0 h-2 w-0.5" />}
+      <div className="bg-border absolute inset-s-8.75 top-14.5 bottom-0 z-0 w-0.5" />
       <div className="flex items-start gap-2">
         <UserAvatar userId={event.pubkey} size="normal" className="shrink-0" />
         <div className="w-0 flex-1">
@@ -364,7 +360,7 @@ function ExpandThreadButton({ expanded, onToggle }: { expanded: boolean; onToggl
       onClick={onToggle}
       className="clickable text-muted-foreground hover:text-foreground hover:bg-accent/30 relative flex w-full items-center gap-2 py-1.5 ps-11 pe-4 text-sm transition-colors"
     >
-      <div className="bg-border absolute inset-s-9 top-0 bottom-0 z-0 w-px" />
+      <div className="bg-border absolute inset-s-8.75 top-0 bottom-0 z-0 w-0.5" />
       {expanded ? <FoldVertical className="size-4" /> : <UnfoldVertical className="size-4" />}
       {expanded ? t('Hide thread context') : t('Show thread context')}
     </button>

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -1,14 +1,25 @@
 import { useSecondaryPage } from '@/PageManager'
+import ClientTag from '@/components/ClientTag'
+import Content from '@/components/Content'
 import ContentPreview from '@/components/ContentPreview'
+import FollowingBadge from '@/components/FollowingBadge'
+import { FormattedTimestamp } from '@/components/FormattedTimestamp'
+import Nip05 from '@/components/Nip05'
 import Note from '@/components/Note'
 import NoteInteractions from '@/components/NoteInteractions'
+import NoteOptions from '@/components/NoteOptions'
+import ProtectedBadge from '@/components/ProtectedBadge'
 import StuffStats from '@/components/StuffStats'
+import TranslateButton from '@/components/TranslateButton'
+import TrustScoreBadge from '@/components/TrustScoreBadge'
 import UserAvatar, { UserAvatarSkeleton } from '@/components/UserAvatar'
+import Username from '@/components/Username'
 import { Card } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ExtendedKind } from '@/constants'
 import { useFetchEvent } from '@/hooks'
+import { useAncestorChain } from '@/hooks/useThread'
 import SecondaryPageLayout from '@/layouts/SecondaryPageLayout'
 import {
   getEventKey,
@@ -20,13 +31,26 @@ import {
 import { toExternalContent, toNote } from '@/lib/link'
 import { tagNameEquals } from '@/lib/tag'
 import { cn } from '@/lib/utils'
-import { Ellipsis } from 'lucide-react'
+import { useScreenSize } from '@/providers/ScreenSizeProvider'
+import threadService from '@/services/thread.service'
+import { TPageRef } from '@/types'
+import { Ellipsis, FoldVertical, UnfoldVertical } from 'lucide-react'
 import { Event } from 'nostr-tools'
-import { forwardRef, useMemo } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import NotFound from './NotFound'
 
-const NotePage = forwardRef(({ id, index }: { id?: string; index?: number }, ref) => {
+const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"]'
+
+const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, index }, ref) => {
   const { t } = useTranslation()
   const { event, isFetching } = useFetchEvent(id)
   const parentEventId = useMemo(() => getParentBech32Id(event), [event])
@@ -37,10 +61,61 @@ const NotePage = forwardRef(({ id, index }: { id?: string; index?: number }, ref
   )
   const { isFetching: isFetchingRootEvent, event: rootEvent } = useFetchEvent(rootEventId)
   const { isFetching: isFetchingParentEvent, event: parentEvent } = useFetchEvent(parentEventId)
+  const [expanded, setExpanded] = useState(false)
+  const currentKey = useMemo(() => (event ? getEventKey(event) : ''), [event])
+  const rootKey = useMemo(() => (rootEvent ? getEventKey(rootEvent) : ''), [rootEvent])
+  const ancestorChain = useAncestorChain(currentKey, rootKey)
+  const canExpand = !!parentEventId
+  const fullChain = useMemo(() => {
+    const items: Event[] = []
+    const seen = new Set<string>()
+    if (rootEvent && rootEventId && rootEventId !== parentEventId) {
+      items.push(rootEvent)
+      seen.add(rootEvent.id)
+    }
+    for (const evt of ancestorChain) {
+      if (seen.has(evt.id)) continue
+      items.push(evt)
+      seen.add(evt.id)
+    }
+    if (parentEvent && !seen.has(parentEvent.id)) {
+      items.push(parentEvent)
+    }
+    return items
+  }, [rootEvent, rootEventId, parentEvent, parentEventId, ancestorChain])
+  const layoutRef = useRef<TPageRef>(null)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToTop: (behavior) => layoutRef.current?.scrollToTop(behavior)
+    }),
+    []
+  )
+
+  const handleToggleExpand = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev
+      if (!next) layoutRef.current?.scrollToTop('instant')
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!expanded || !event) return
+    threadService.subscribe(event)
+    return () => {
+      threadService.unsubscribe(event)
+    }
+  }, [expanded, event])
+
+  useEffect(() => {
+    if (!canExpand) setExpanded(false)
+  }, [canExpand])
 
   if (!event && isFetching) {
     return (
-      <SecondaryPageLayout ref={ref} index={index} title={t('Note')}>
+      <SecondaryPageLayout ref={layoutRef} index={index} title={t('Note')}>
         <div className="px-4 pt-3">
           <div className="flex items-center gap-2">
             <UserAvatarSkeleton className="h-10 w-10" />
@@ -67,48 +142,69 @@ const NotePage = forwardRef(({ id, index }: { id?: string; index?: number }, ref
   }
   if (!event) {
     return (
-      <SecondaryPageLayout ref={ref} index={index} title={t('Note')} displayScrollToTopButton>
+      <SecondaryPageLayout ref={layoutRef} index={index} title={t('Note')} displayScrollToTopButton>
         <NotFound bech32Id={id} />
       </SecondaryPageLayout>
     )
   }
 
   return (
-    <SecondaryPageLayout ref={ref} index={index} title={t('Note')} displayScrollToTopButton>
-      <div className="px-4 pt-3">
-        {rootITag && <ExternalRoot value={rootITag[1]} />}
-        {rootEventId && rootEventId !== parentEventId && (
-          <ParentNote
-            key={`root-note-${event.id}`}
-            isFetching={isFetchingRootEvent}
-            event={rootEvent}
-            eventBech32Id={rootEventId}
-            isConsecutive={isConsecutive(rootEvent, parentEvent)}
-          />
+    <SecondaryPageLayout ref={layoutRef} index={index} title={t('Note')} displayScrollToTopButton>
+      <div>
+        {rootITag && (
+          <div className="px-4 pt-3">
+            <ExternalRoot value={rootITag[1]} />
+          </div>
         )}
-        {parentEventId && (
-          <ParentNote
-            key={`parent-note-${event.id}`}
-            isFetching={isFetchingParentEvent}
-            event={parentEvent}
-            eventBech32Id={parentEventId}
+        {expanded
+          ? fullChain.map((ancestor, idx) => (
+              <ChainItem
+                key={`chain-${ancestor.id}`}
+                event={ancestor}
+                isFirst={idx === 0 && !rootITag}
+              />
+            ))
+          : canExpand && (
+              <div className={cn('px-4', !rootITag && 'pt-3')}>
+                {rootEventId && rootEventId !== parentEventId && (
+                  <ParentNote
+                    key={`root-note-${event.id}`}
+                    isFetching={isFetchingRootEvent}
+                    event={rootEvent}
+                    eventBech32Id={rootEventId}
+                    isConsecutive={isConsecutive(rootEvent, parentEvent)}
+                  />
+                )}
+                {parentEventId && (
+                  <ParentNote
+                    key={`parent-note-${event.id}`}
+                    isFetching={isFetchingParentEvent}
+                    event={parentEvent}
+                    eventBech32Id={parentEventId}
+                    noConnector
+                  />
+                )}
+                <div className="bg-border ms-5 h-1 w-px" />
+              </div>
+            )}
+        {canExpand && <ExpandThreadButton expanded={expanded} onToggle={handleToggleExpand} />}
+        <div className={cn('relative px-4 pt-3', canExpand && 'pt-1')}>
+          <Note
+            key={`note-${event.id}`}
+            event={event}
+            className="select-text"
+            hideParentNotePreview
+            originalNoteId={id}
+            showFull
           />
-        )}
-        <Note
-          key={`note-${event.id}`}
-          event={event}
-          className="select-text"
-          hideParentNotePreview
-          originalNoteId={id}
-          showFull
-        />
-        <StuffStats
-          className="mt-3"
-          classNames={{ topList: '-mx-4', topListContent: 'px-4' }}
-          stuff={event}
-          fetchIfNotExisting
-          displayTopZapsAndLikes
-        />
+          <StuffStats
+            className="mt-3"
+            classNames={{ topList: '-mx-4', topListContent: 'px-4' }}
+            stuff={event}
+            fetchIfNotExisting
+            displayTopZapsAndLikes
+          />
+        </div>
       </div>
       <Separator className="mt-4" />
       <NoteInteractions key={`note-interactions-${event.id}`} event={event} />
@@ -138,12 +234,14 @@ function ParentNote({
   event,
   eventBech32Id,
   isFetching,
-  isConsecutive = true
+  isConsecutive = true,
+  noConnector = false
 }: {
   event?: Event
   eventBech32Id: string
   isFetching: boolean
   isConsecutive?: boolean
+  noConnector?: boolean
 }) {
   const { push } = useSecondaryPage()
 
@@ -156,7 +254,7 @@ function ParentNote({
             <Skeleton className="h-3" />
           </div>
         </div>
-        <div className="bg-border ms-5 h-3 w-px" />
+        {!noConnector && <div className="bg-border ms-5 h-3 w-px" />}
       </div>
     )
   }
@@ -175,11 +273,12 @@ function ParentNote({
         {event && <UserAvatar userId={event.pubkey} size="tiny" className="shrink-0" />}
         <ContentPreview className="truncate" event={event} />
       </div>
-      {isConsecutive ? (
-        <div className="bg-border ms-5 h-3 w-px" />
-      ) : (
-        <Ellipsis className="text-muted-foreground/60 ms-3.5 size-3" />
-      )}
+      {!noConnector &&
+        (isConsecutive ? (
+          <div className="bg-border ms-5 h-3 w-px" />
+        ) : (
+          <Ellipsis className="text-muted-foreground/60 ms-3.5 size-3" />
+        ))}
     </div>
   )
 }
@@ -191,4 +290,78 @@ function isConsecutive(rootEvent?: Event, parentEvent?: Event) {
   if (!tag) return false
 
   return getEventKey(rootEvent) === getKeyFromTag(tag.tag)
+}
+
+function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
+  const { push } = useSecondaryPage()
+  const { isSmallScreen } = useScreenSize()
+
+  return (
+    <div
+      className="clickable hover:bg-accent/30 relative px-4 py-3 transition-colors duration-200"
+      onClick={(e) => {
+        const target = e.target
+        if (!(target instanceof Node) || !e.currentTarget.contains(target)) return
+        if (target instanceof Element && target.closest(INTERACTIVE_SELECTOR)) return
+        push(toNote(event))
+      }}
+    >
+      <div
+        className={cn(
+          'bg-border absolute inset-s-9 bottom-0 z-0 w-px',
+          isFirst ? 'top-15' : 'top-0'
+        )}
+      />
+      <div className="flex items-start gap-2">
+        <UserAvatar userId={event.pubkey} size="normal" className="shrink-0" />
+        <div className="w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <Username
+                  userId={event.pubkey}
+                  className="flex truncate font-semibold"
+                  skeletonClassName="h-4"
+                />
+                <FollowingBadge pubkey={event.pubkey} />
+                <TrustScoreBadge pubkey={event.pubkey} />
+                <ProtectedBadge event={event} />
+                <ClientTag event={event} />
+              </div>
+              <div className="text-muted-foreground flex items-center gap-1 text-sm">
+                <Nip05 pubkey={event.pubkey} append="·" />
+                <FormattedTimestamp
+                  timestamp={event.created_at}
+                  className="shrink-0"
+                  short={isSmallScreen}
+                />
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center">
+              <TranslateButton event={event} className="py-0" />
+              <NoteOptions event={event} className="shrink-0 [&_svg]:size-5" />
+            </div>
+          </div>
+          <Content className="mt-2" event={event} />
+          <StuffStats className="mt-2" stuff={event} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ExpandThreadButton({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
+  const { t } = useTranslation()
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="clickable text-muted-foreground hover:text-foreground hover:bg-accent/30 relative flex w-full items-center gap-2 py-1.5 ps-11 pe-4 text-sm transition-colors"
+    >
+      <div className="bg-border absolute inset-s-9 top-0 bottom-0 z-0 w-px" />
+      {expanded ? <FoldVertical className="size-4" /> : <UnfoldVertical className="size-4" />}
+      {expanded ? t('Hide thread context') : t('Show thread context')}
+    </button>
+  )
 }

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -31,6 +31,7 @@ import {
 import { toExternalContent, toNote } from '@/lib/link'
 import { tagNameEquals } from '@/lib/tag'
 import { cn } from '@/lib/utils'
+import { useContentPolicy } from '@/providers/ContentPolicyProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import threadService from '@/services/thread.service'
 import { TPageRef } from '@/types'
@@ -53,6 +54,7 @@ const INTERACTIVE_SELECTOR = 'button, a, input, textarea, select, [role="button"
 
 const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, index }, ref) => {
   const { t } = useTranslation()
+  const { autoLoadProfilePicture } = useContentPolicy()
   const { event, isFetching } = useFetchEvent(id)
   const parentEventId = useMemo(() => getParentBech32Id(event), [event])
   const rootEventId = useMemo(() => getRootBech32Id(event), [event])
@@ -189,7 +191,7 @@ const NotePage = forwardRef<TPageRef, { id?: string; index?: number }>(({ id, in
                     noConnector
                   />
                 )}
-                <div className="bg-border ms-4.75 h-1.5 w-0.5" />
+                {autoLoadProfilePicture && <div className="bg-border ms-4.75 h-1.5 w-0.5" />}
               </div>
             )}
         {canExpand && <ExpandThreadButton expanded={expanded} onToggle={handleToggleExpand} />}
@@ -221,6 +223,7 @@ export default NotePage
 
 function ExternalRoot({ value }: { value: string }) {
   const { push } = useSecondaryPage()
+  const { autoLoadProfilePicture } = useContentPolicy()
 
   return (
     <div>
@@ -230,7 +233,11 @@ function ExternalRoot({ value }: { value: string }) {
       >
         <div className="truncate">{value}</div>
       </Card>
-      <div className="bg-border ms-5 h-2 w-px" />
+      {autoLoadProfilePicture ? (
+        <div className="bg-border ms-5 h-2 w-px" />
+      ) : (
+        <div className="h-2" />
+      )}
     </div>
   )
 }
@@ -249,6 +256,9 @@ function ParentNote({
   noConnector?: boolean
 }) {
   const { push } = useSecondaryPage()
+  const { autoLoadProfilePicture } = useContentPolicy()
+  const showLine = !noConnector && autoLoadProfilePicture
+  const showSpacer = !noConnector && !autoLoadProfilePicture
 
   if (isFetching) {
     return (
@@ -259,7 +269,11 @@ function ParentNote({
             <Skeleton className="h-3" />
           </div>
         </div>
-        {!noConnector && <div className="bg-border ms-4.75 h-3 w-0.5" />}
+        {showLine ? (
+          <div className="bg-border ms-4.75 h-3 w-0.5" />
+        ) : showSpacer ? (
+          <div className="h-1.5" />
+        ) : null}
       </div>
     )
   }
@@ -278,12 +292,13 @@ function ParentNote({
         {event && <UserAvatar userId={event.pubkey} size="tiny" className="shrink-0" />}
         <ContentPreview className="truncate" event={event} />
       </div>
-      {!noConnector &&
-        (isConsecutive ? (
-          <div className="bg-border ms-4.75 h-3 w-0.5" />
-        ) : (
-          <Ellipsis className="text-muted-foreground/60 ms-3.5 size-3" />
-        ))}
+      {!isConsecutive ? (
+        <Ellipsis className="text-muted-foreground/60 ms-3.5 size-3" />
+      ) : showLine ? (
+        <div className="bg-border ms-4.75 h-3 w-0.5" />
+      ) : showSpacer ? (
+        <div className="h-1.5" />
+      ) : null}
     </div>
   )
 }
@@ -300,10 +315,14 @@ function isConsecutive(rootEvent?: Event, parentEvent?: Event) {
 function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
   const { push } = useSecondaryPage()
   const { isSmallScreen } = useScreenSize()
+  const { autoLoadProfilePicture } = useContentPolicy()
 
   return (
     <div
-      className="clickable hover:bg-accent/30 relative px-4 py-3 transition-colors duration-200"
+      className={cn(
+        'clickable hover:bg-accent/30 relative px-4 py-3 transition-colors duration-200',
+        !autoLoadProfilePicture && 'border-b'
+      )}
       onClick={(e) => {
         const target = e.target
         if (!(target instanceof Node) || !e.currentTarget.contains(target)) return
@@ -311,8 +330,12 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
         push(toNote(event))
       }}
     >
-      {!isFirst && <div className="bg-border absolute inset-s-8.75 top-0 z-0 h-2 w-0.5" />}
-      <div className="bg-border absolute inset-s-8.75 top-14.5 bottom-0 z-0 w-0.5" />
+      {autoLoadProfilePicture && !isFirst && (
+        <div className="bg-border absolute inset-s-8.75 top-0 z-0 h-2 w-0.5" />
+      )}
+      {autoLoadProfilePicture && (
+        <div className="bg-border absolute inset-s-8.75 top-14.5 bottom-0 z-0 w-0.5" />
+      )}
       <div className="flex items-start gap-2">
         <UserAvatar userId={event.pubkey} size="normal" className="shrink-0" />
         <div className="w-0 flex-1">
@@ -353,14 +376,20 @@ function ChainItem({ event, isFirst }: { event: Event; isFirst: boolean }) {
 
 function ExpandThreadButton({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
   const { t } = useTranslation()
+  const { autoLoadProfilePicture } = useContentPolicy()
 
   return (
     <button
       type="button"
       onClick={onToggle}
-      className="clickable text-muted-foreground hover:text-foreground hover:bg-accent/30 relative flex w-full items-center gap-2 py-1.5 ps-11 pe-4 text-sm transition-colors"
+      className={cn(
+        'clickable text-muted-foreground hover:text-foreground hover:bg-accent/30 relative flex w-full items-center gap-2 py-1.5 pe-4 text-sm transition-colors',
+        autoLoadProfilePicture ? 'ps-16' : 'border-b ps-4'
+      )}
     >
-      <div className="bg-border absolute inset-s-8.75 top-0 bottom-0 z-0 w-0.5" />
+      {autoLoadProfilePicture && (
+        <div className="bg-border absolute inset-s-8.75 top-0 bottom-0 z-0 w-0.5" />
+      )}
       {expanded ? <FoldVertical className="size-4" /> : <UnfoldVertical className="size-4" />}
       {expanded ? t('Hide thread context') : t('Show thread context')}
     </button>

--- a/src/services/thread.service.ts
+++ b/src/services/thread.service.ts
@@ -38,13 +38,13 @@ class ThreadService {
   private threadMap = new Map<string, NostrEvent[]>()
   private processedReplyKeys = new Set<string>()
   private parentKeyMap = new Map<string, string>()
-  private eventByKey = new Map<string, NostrEvent>()
   private descendantCache = new Map<string, Map<string, NostrEvent[]>>()
-  private ancestorChainCache = new Map<string, NostrEvent[]>()
+  private ancestorChainCache = new Map<string, string[]>()
 
   private threadListeners = new Map<string, Set<() => void>>()
   private allDescendantThreadsListeners = new Map<string, Set<() => void>>()
   private readonly EMPTY_ARRAY: NostrEvent[] = []
+  private readonly EMPTY_STRING_ARRAY: string[] = []
   private readonly EMPTY_MAP: Map<string, NostrEvent[]> = new Map()
 
   constructor() {
@@ -207,7 +207,7 @@ class ThreadService {
       const key = getEventKey(reply)
       if (this.processedReplyKeys.has(key)) return
       this.processedReplyKeys.add(key)
-      this.eventByKey.set(key, reply)
+      client.addEventToCache(reply)
 
       if (!isReplyNoteEvent(reply)) return
 
@@ -238,29 +238,23 @@ class ThreadService {
     }
   }
 
-  getEventByKey(key: string): NostrEvent | undefined {
-    return this.eventByKey.get(key)
-  }
+  getAncestorChain(currentKey: string, rootKey: string): string[] {
+    if (!currentKey || !rootKey || currentKey === rootKey) return this.EMPTY_STRING_ARRAY
 
-  getAncestorChain(currentKey: string, rootKey: string): NostrEvent[] {
-    if (!currentKey || !rootKey || currentKey === rootKey) return this.EMPTY_ARRAY
-
-    const cacheKey = `${currentKey}${rootKey}`
+    const cacheKey = `${currentKey}:${rootKey}`
     const cached = this.ancestorChainCache.get(cacheKey)
     if (cached) return cached
 
-    const chain: NostrEvent[] = []
+    const chain: string[] = []
     const visited = new Set<string>([currentKey])
     let key: string | undefined = this.parentKeyMap.get(currentKey)
     while (key && key !== rootKey && !visited.has(key)) {
-      const event = this.eventByKey.get(key)
-      if (!event) break
-      chain.unshift(event)
+      chain.unshift(key)
       visited.add(key)
       key = this.parentKeyMap.get(key)
     }
 
-    const result = chain.length === 0 ? this.EMPTY_ARRAY : chain
+    const result = chain.length === 0 ? this.EMPTY_STRING_ARRAY : chain
     this.ancestorChainCache.set(cacheKey, result)
     return result
   }

--- a/src/services/thread.service.ts
+++ b/src/services/thread.service.ts
@@ -38,7 +38,9 @@ class ThreadService {
   private threadMap = new Map<string, NostrEvent[]>()
   private processedReplyKeys = new Set<string>()
   private parentKeyMap = new Map<string, string>()
+  private eventByKey = new Map<string, NostrEvent>()
   private descendantCache = new Map<string, Map<string, NostrEvent[]>>()
+  private ancestorChainCache = new Map<string, NostrEvent[]>()
 
   private threadListeners = new Map<string, Set<() => void>>()
   private allDescendantThreadsListeners = new Map<string, Set<() => void>>()
@@ -205,6 +207,7 @@ class ThreadService {
       const key = getEventKey(reply)
       if (this.processedReplyKeys.has(key)) return
       this.processedReplyKeys.add(key)
+      this.eventByKey.set(key, reply)
 
       if (!isReplyNoteEvent(reply)) return
 
@@ -228,10 +231,38 @@ class ThreadService {
     }
 
     this.descendantCache.clear()
+    this.ancestorChainCache.clear()
     for (const key of newReplyEventMap.keys()) {
       this.notifyThreadUpdate(key)
       this.notifyAllDescendantThreadsUpdate(key)
     }
+  }
+
+  getEventByKey(key: string): NostrEvent | undefined {
+    return this.eventByKey.get(key)
+  }
+
+  getAncestorChain(currentKey: string, rootKey: string): NostrEvent[] {
+    if (!currentKey || !rootKey || currentKey === rootKey) return this.EMPTY_ARRAY
+
+    const cacheKey = `${currentKey}${rootKey}`
+    const cached = this.ancestorChainCache.get(cacheKey)
+    if (cached) return cached
+
+    const chain: NostrEvent[] = []
+    const visited = new Set<string>([currentKey])
+    let key: string | undefined = this.parentKeyMap.get(currentKey)
+    while (key && key !== rootKey && !visited.has(key)) {
+      const event = this.eventByKey.get(key)
+      if (!event) break
+      chain.unshift(event)
+      visited.add(key)
+      key = this.parentKeyMap.get(key)
+    }
+
+    const result = chain.length === 0 ? this.EMPTY_ARRAY : chain
+    this.ancestorChainCache.set(cacheKey, result)
+    return result
   }
 
   getThread(stuffKey: string): NostrEvent[] {


### PR DESCRIPTION
## Summary
- Add a Show / Hide thread context toggle on NotePage that expands the full ancestor chain Twitter-style (avatar, content, stats, translate, options, badges) connected by a continuous left-side thread guide line
- One subscription to the root subtree powers the chain; new useAncestorChain hook and thread-service helpers walk from the current event up to root, with ancestor-chain caching invalidated on incoming replies
- Move the bookmark action from StuffStats into the NoteOptions menu so the reaction bar stays focused on reactions

## Test plan
- [ ] On a deep reply, click Show thread context and verify the full chain expands inline with a continuous left-side line and the focal note connects to the chain
- [ ] Click Hide thread context and verify the page auto-scrolls back to top
- [ ] On a top-level note (no parent), verify the toggle is hidden
- [ ] On a single-parent thread, verify the toggle still appears and expansion works (no duplicate parent)
- [ ] Click translate / options / stats buttons inside a chain item and verify they do not navigate away
- [ ] Open the options menu on any note and verify the new Bookmark / Remove bookmark action toggles correctly and persists across refresh
- [ ] Confirm the StuffStats row no longer shows the bookmark icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)