### PR TITLE
refactor(post-editor): overhaul UI/UX

### DIFF
--- a/src/components/PostEditor/ParentEventPreview.tsx
+++ b/src/components/PostEditor/ParentEventPreview.tsx
@@ -1,0 +1,67 @@
+import Note from '@/components/Note'
+import { cn } from '@/lib/utils'
+import { Event } from 'nostr-tools'
+import { useEffect, useRef, useState } from 'react'
+
+export default function ParentEventPreview({
+  parentEvent,
+  highlightedText
+}: {
+  parentEvent: Event
+  highlightedText?: string
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [showTopFade, setShowTopFade] = useState(false)
+  const [showBottomFade, setShowBottomFade] = useState(false)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const update = () => {
+      const { scrollTop, scrollHeight, clientHeight } = el
+      setShowTopFade(scrollTop > 0)
+      setShowBottomFade(scrollTop + clientHeight < scrollHeight - 1)
+    }
+
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    Array.from(el.children).forEach((child) => ro.observe(child))
+
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+    }
+  }, [parentEvent, highlightedText])
+
+  return (
+    <div className="relative">
+      <div ref={scrollRef} className="max-h-64 overflow-y-auto">
+        <div className="pointer-events-none px-5 py-3 sm:px-6">
+          {highlightedText ? (
+            <div className="flex gap-4">
+              <div className="my-1 w-1 shrink-0 rounded-md bg-primary/60" />
+              <div className="whitespace-pre-line italic">{highlightedText}</div>
+            </div>
+          ) : (
+            <Note size="small" event={parentEvent} hideParentNotePreview />
+          )}
+        </div>
+      </div>
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-background to-transparent transition-opacity duration-200',
+          showTopFade ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent transition-opacity duration-200',
+          showBottomFade ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+    </div>
+  )
+}

--- a/src/components/PostEditor/PollEditor.tsx
+++ b/src/components/PostEditor/PollEditor.tsx
@@ -1,15 +1,17 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { normalizeUrl } from '@/lib/url'
 import { TPollCreateData } from '@/types'
 import dayjs from 'dayjs'
-import { ChevronRight, Eraser, ListTodo, Plus, Trash2, TriangleAlert, X } from 'lucide-react'
+import { ChevronRight, Eraser, Plus, Trash2, TriangleAlert, X } from 'lucide-react'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+const inputClass =
+  'h-9 rounded-md border-0 bg-muted/40 transition-colors duration-200 hover:bg-muted/50 focus-visible:bg-muted/60 focus-visible:ring-0 focus-visible:border-0'
 
 export default function PollEditor({
   pollCreateData,
@@ -60,36 +62,18 @@ export default function PollEditor({
   }
 
   return (
-    <div className="bg-muted/10 space-y-5 rounded-lg border p-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm font-semibold">
-          <ListTodo className="text-primary size-4" />
-          <span>{t('Poll')}</span>
-        </div>
-        <Button
-          type="button"
-          variant="ghost-destructive"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={() => setIsPoll(false)}
-        >
-          <Trash2 />
-          {t('Remove poll')}
-        </Button>
-      </div>
-
-      <div className="space-y-2">
-        <div className="text-muted-foreground text-xs font-medium">{t('Options')}</div>
+    <div className="overflow-hidden rounded-2xl border">
+      <div className="space-y-2 p-3">
         {options.map((option, index) => (
           <div key={index} className="group relative">
-            <div className="text-muted-foreground pointer-events-none absolute inset-y-0 start-3 flex items-center text-xs font-medium tabular-nums">
+            <div className="pointer-events-none absolute inset-y-0 start-3 flex items-center text-xs font-medium tabular-nums text-muted-foreground">
               {index + 1}.
             </div>
             <Input
               value={option}
               onChange={(e) => handleOptionChange(index, e.target.value)}
               placeholder={t('Option {{number}}', { number: index + 1 })}
-              className="ps-9 pe-10"
+              className={cn(inputClass, 'ps-9 pe-10')}
               maxLength={200}
             />
             {options.length > 2 && (
@@ -97,7 +81,7 @@ export default function PollEditor({
                 type="button"
                 onClick={() => handleRemoveOption(index)}
                 title={t('Remove')}
-                className="text-muted-foreground hover:bg-destructive/15 hover:text-destructive absolute inset-y-0 end-2 my-auto flex h-7 w-7 items-center justify-center rounded-md opacity-0 transition group-hover:opacity-100 focus-visible:opacity-100"
+                className="absolute inset-y-0 end-2 my-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition hover:bg-destructive/15 hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100"
               >
                 <X className="size-4" />
               </button>
@@ -107,85 +91,101 @@ export default function PollEditor({
         <button
           type="button"
           onClick={handleAddOption}
-          className="border-input bg-background text-muted-foreground hover:border-ring/50 hover:bg-accent/40 hover:text-foreground flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-dashed text-sm transition-all duration-200"
+          className="flex h-9 w-full items-center justify-center gap-2 rounded-md text-sm text-muted-foreground transition-colors duration-200 hover:bg-muted/40 hover:text-foreground"
         >
           <Plus className="size-4" />
           {t('Add Option')}
         </button>
       </div>
 
-      <div className="bg-background overflow-hidden rounded-lg border">
-        <div className="flex items-center justify-between gap-3 px-3 py-2.5">
-          <Label htmlFor="multiple-choice" className="cursor-pointer text-sm">
-            {t('Allow multiple choices')}
-          </Label>
-          <Switch
-            id="multiple-choice"
-            checked={isMultipleChoice}
-            onCheckedChange={setIsMultipleChoice}
-          />
-        </div>
-        <Separator />
-        <div className="flex items-center justify-between gap-3 px-3 py-2.5">
-          <Label htmlFor="ends-at" className="cursor-pointer text-sm">
-            {t('End date')}
-          </Label>
-          <div className="flex items-center gap-1">
-            <Input
-              id="ends-at"
-              type="datetime-local"
-              value={endsAt}
-              onChange={(e) => setEndsAt(e.target.value)}
-              className="h-8 w-auto text-sm"
-            />
-            {endsAt && (
-              <button
-                type="button"
-                onClick={() => setEndsAt('')}
-                title={t('Clear end date')}
-                className="text-muted-foreground hover:bg-destructive/15 hover:text-destructive flex h-7 w-7 items-center justify-center rounded-md transition"
-              >
-                <Eraser className="size-4" />
-              </button>
-            )}
-          </div>
-        </div>
-      </div>
+      <div className="h-px bg-border" />
 
-      <div>
-        <button
-          type="button"
-          onClick={() => setShowAdvanced((v) => !v)}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs font-medium transition"
-        >
-          <ChevronRight
-            className={cn(
-              'size-3 transition-transform rtl:-scale-x-100',
-              showAdvanced && 'rotate-90'
-            )}
-          />
-          {t('Advanced options')}
-        </button>
-        {showAdvanced && (
-          <div className="mt-2 grid gap-1.5">
-            <Label htmlFor="relay-urls" className="text-muted-foreground text-xs">
-              {t('Relay URLs (optional, comma-separated)')}
+      <div className="px-3 py-2">
+        <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-2">
+          <div className="flex items-center justify-between gap-3 py-1.5">
+            <Label htmlFor="multiple-choice" className="cursor-pointer text-sm font-normal">
+              {t('Allow multiple choices')}
             </Label>
-            <Input
-              id="relay-urls"
-              value={relayUrls}
-              onChange={(e) => setRelayUrls(e.target.value)}
-              placeholder="wss://relay1.com, wss://relay2.com"
-              className="text-sm"
+            <Switch
+              id="multiple-choice"
+              checked={isMultipleChoice}
+              onCheckedChange={setIsMultipleChoice}
             />
           </div>
-        )}
+          <div className="flex items-center justify-between gap-3 py-1.5">
+            <Label htmlFor="ends-at" className="cursor-pointer text-sm font-normal">
+              {t('End date')}
+            </Label>
+            <div className="flex items-center gap-1">
+              <Input
+                id="ends-at"
+                type="datetime-local"
+                value={endsAt}
+                onChange={(e) => setEndsAt(e.target.value)}
+                className={cn(inputClass, 'h-8 w-auto text-sm')}
+              />
+              {endsAt && (
+                <button
+                  type="button"
+                  onClick={() => setEndsAt('')}
+                  title={t('Clear end date')}
+                  className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-destructive/15 hover:text-destructive"
+                >
+                  <Eraser className="size-4" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="py-1.5">
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="flex items-center gap-1 text-xs font-medium text-muted-foreground transition hover:text-foreground"
+          >
+            <ChevronRight
+              className={cn(
+                'size-3 transition-transform rtl:-scale-x-100',
+                showAdvanced && 'rotate-90'
+              )}
+            />
+            {t('Advanced options')}
+          </button>
+          {showAdvanced && (
+            <div className="mt-2 grid gap-1.5">
+              <Label htmlFor="relay-urls" className="text-xs text-muted-foreground">
+                {t('Relay URLs (optional, comma-separated)')}
+              </Label>
+              <Input
+                id="relay-urls"
+                value={relayUrls}
+                onChange={(e) => setRelayUrls(e.target.value)}
+                placeholder="wss://relay1.com, wss://relay2.com"
+                className={cn(inputClass, 'text-sm')}
+              />
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="text-muted-foreground flex items-start gap-2 text-xs">
+      <div className="h-px bg-border" />
+
+      <div className="flex items-start gap-2 px-3 py-2 text-xs text-muted-foreground">
         <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
         <span>{t('Polls may not display on clients that don’t support them.')}</span>
       </div>
+
+      <div className="h-px bg-border" />
+
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-9 w-full gap-1.5 rounded-none text-sm font-medium text-destructive hover:bg-destructive/10 hover:text-destructive"
+        onClick={() => setIsPoll(false)}
+      >
+        <Trash2 className="size-4" />
+        {t('Remove poll')}
+      </Button>
     </div>
   )
 }

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -1,6 +1,5 @@
-import Note from '@/components/Note'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   createCommentDraftEvent,
   createHighlightDraftEvent,
@@ -14,16 +13,23 @@ import mediaUpload from '@/services/media-upload.service'
 import postEditorCache from '@/services/post-editor-cache.service'
 import threadService from '@/services/thread.service'
 import { TPollCreateData } from '@/types'
-import { CircleHelp, ImageUp, ListTodo, LoaderCircle, Settings, Smile, X } from 'lucide-react'
+import {
+  CircleHelp,
+  ImageUp,
+  ListTodo,
+  LoaderCircle,
+  Lock,
+  Settings,
+  Smile,
+  X
+} from 'lucide-react'
 import { Event, kinds } from 'nostr-tools'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { Label } from '@/components/ui/label'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Switch } from '@/components/ui/switch'
 import ExpressionPickerDialog from '../ExpressionPickerDialog'
 import Mentions from './Mentions'
+import ParentEventPreview from './ParentEventPreview'
 import PollEditor from './PollEditor'
 import PostOptions from './PostOptions'
 import PostRelaySelector from './PostRelaySelector'
@@ -209,21 +215,46 @@ export default function PostContent({
   }
 
   return (
-    <div className="space-y-2">
-      {parentEvent && (
-        <ScrollArea className="flex max-h-48 flex-col overflow-y-auto rounded-lg border bg-muted/40">
-          <div className="pointer-events-none p-2 sm:p-3">
-            {highlightedText ? (
-              <div className="flex gap-4">
-                <div className="my-1 w-1 shrink-0 rounded-md bg-primary/60" />
-                <div className="whitespace-pre-line italic">{highlightedText}</div>
+    <div className="pb-2">
+
+      {uploadProgresses.length > 0 && (
+        <div className="space-y-2 px-5 pb-3 sm:px-6">
+          {uploadProgresses.map(({ file, progress, cancel }, index) => (
+            <div key={`${file.name}-${index}`} className="flex items-end gap-2">
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 truncate text-xs text-muted-foreground">
+                  {file.name ?? t('Uploading...')}
+                </div>
+                <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-primary transition-[width] duration-200 ease-out"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
               </div>
-            ) : (
-              <Note size="small" event={parentEvent} hideParentNotePreview />
-            )}
-          </div>
-        </ScrollArea>
+              <button
+                type="button"
+                onClick={() => {
+                  cancel?.()
+                  handleUploadEnd(file)
+                }}
+                className="text-muted-foreground hover:text-foreground"
+                title={t('Cancel')}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+        </div>
       )}
+
+      {parentEvent && (
+        <>
+          <ParentEventPreview parentEvent={parentEvent} highlightedText={highlightedText} />
+          <div className="h-px bg-border" />
+        </>
+      )}
+
       <PostTextarea
         ref={textareaRef}
         text={text}
@@ -235,79 +266,77 @@ export default function PostContent({
         onUploadStart={handleUploadStart}
         onUploadProgress={handleUploadProgress}
         onUploadEnd={handleUploadEnd}
-        placeholder={highlightedText ? t('Write your thoughts about this highlight...') : undefined}
+        placeholder={
+          highlightedText ? t('Write your thoughts about this highlight...') : undefined
+        }
+        topRightActions={
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!canPost}
+            onClick={post}
+            className="px-4 text-sm font-semibold shadow-sm"
+          >
+            {posting && <LoaderCircle className="animate-spin" />}
+            {parentStuff ? (highlightedText ? t('Publish Highlight') : t('Reply')) : t('Post')}
+          </Button>
+        }
       />
+
       {isPoll && (
-        <PollEditor
-          pollCreateData={pollCreateData}
-          setPollCreateData={setPollCreateData}
-          setIsPoll={setIsPoll}
-        />
-      )}
-      {uploadProgresses.length > 0 &&
-        uploadProgresses.map(({ file, progress, cancel }, index) => (
-          <div key={`${file.name}-${index}`} className="mt-2 flex items-end gap-2">
-            <div className="min-w-0 flex-1">
-              <div className="mb-1 truncate text-xs text-muted-foreground">
-                {file.name ?? t('Uploading...')}
-              </div>
-              <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full bg-primary transition-[width] duration-200 ease-out"
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                cancel?.()
-                handleUploadEnd(file)
-              }}
-              className="text-muted-foreground hover:text-foreground"
-              title={t('Cancel')}
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        ))}
-      {!isPoll && (
-        <div className="flex items-center gap-3">
-          <div className="min-w-0">
-          <PostRelaySelector
-            onProtectedSuggestionChange={handleProtectedSuggestionChange}
-            setAdditionalRelayUrls={setAdditionalRelayUrls}
-            parentEvent={parentEvent}
-            openFrom={openFrom}
+        <div className="px-5 pb-3 sm:px-6">
+          <PollEditor
+            pollCreateData={pollCreateData}
+            setPollCreateData={setPollCreateData}
+            setIsPoll={setIsPoll}
           />
-          </div>
-          <div className="flex shrink-0 items-center gap-1.5">
-            <Switch
-              id="protected-event"
-              checked={isProtectedEvent}
-              onCheckedChange={handleProtectedToggle}
-            />
-            <Label
-              htmlFor="protected-event"
-              className="cursor-pointer text-xs text-muted-foreground"
+        </div>
+      )}
+
+      {!isPoll && (
+        <div className="flex items-center gap-2 px-3 py-2 sm:px-4">
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className={
+                isProtectedEvent
+                  ? 'h-9 gap-1.5 bg-emerald-500/15 px-2.5 text-sm font-normal text-emerald-600 hover:bg-emerald-500/20 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400'
+                  : 'h-9 gap-1.5 px-2.5 text-sm font-normal text-muted-foreground hover:text-foreground'
+              }
+              onClick={() => handleProtectedToggle(!isProtectedEvent)}
             >
-              {t('Protected')}
-            </Label>
+              <Lock className="size-4 shrink-0" />
+              <span>{t('Protected')}</span>
+            </Button>
             <Popover>
               <PopoverTrigger asChild>
-                <button type="button" className="flex shrink-0">
-                  <CircleHelp className="size-3.5! text-muted-foreground" />
-                </button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 text-muted-foreground hover:text-foreground"
+                  title={t('Protected event hint')}
+                >
+                  <CircleHelp className="size-4!" />
+                </Button>
               </PopoverTrigger>
-              <PopoverContent className="text-sm">
-                {t('Protected event hint')}
-              </PopoverContent>
+              <PopoverContent className="text-sm">{t('Protected event hint')}</PopoverContent>
             </Popover>
+          </div>
+          <div className="flex min-w-0 flex-1 justify-end">
+            <PostRelaySelector
+              onProtectedSuggestionChange={handleProtectedSuggestionChange}
+              setAdditionalRelayUrls={setAdditionalRelayUrls}
+              parentEvent={parentEvent}
+              openFrom={openFrom}
+            />
           </div>
         </div>
       )}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+
+      <div className="h-px bg-border" />
+      <div className="flex items-center justify-between gap-2 px-3 py-2 sm:px-4">
+        <div className="flex items-center gap-0.5">
           <Uploader
             onUploadSuccess={({ url }) => {
               textareaRef.current?.appendText(url, true)
@@ -317,7 +346,7 @@ export default function PostContent({
             onProgress={handleUploadProgress}
             accept="image/*,video/*,audio/*"
           >
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" title={t('Upload')}>
               <ImageUp />
             </Button>
           </Uploader>
@@ -339,7 +368,7 @@ export default function PostContent({
               textareaRef.current?.appendText(gif.url, true)
             }}
           >
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" title={t('Emoji')}>
               <Smile />
             </Button>
           </ExpressionPickerDialog>
@@ -348,7 +377,7 @@ export default function PostContent({
               variant="ghost"
               size="icon"
               title={t('Create Poll')}
-              className={isPoll ? 'bg-accent' : ''}
+              className={isPoll ? 'bg-muted text-foreground' : ''}
               onClick={handlePollToggle}
             >
               <ListTodo />
@@ -357,7 +386,8 @@ export default function PostContent({
           <Button
             variant="ghost"
             size="icon"
-            className={showMoreOptions ? 'bg-accent' : ''}
+            title={t('Post settings')}
+            className={showMoreOptions ? 'bg-muted text-foreground' : ''}
             onClick={() => setShowMoreOptions((pre) => !pre)}
           >
             <Settings />
@@ -370,9 +400,10 @@ export default function PostContent({
             mentions={mentions}
             setMentions={setMentions}
           />
-          <div className="flex items-center gap-2 max-sm:hidden">
+          <div className="hidden items-center gap-2 sm:flex">
             <Button
-              variant="secondary"
+              variant="ghost"
+              className="text-muted-foreground hover:text-foreground"
               onClick={(e) => {
                 e.stopPropagation()
                 close()
@@ -380,39 +411,36 @@ export default function PostContent({
             >
               {t('Cancel')}
             </Button>
-            <Button type="submit" disabled={!canPost} onClick={post}>
+            <Button
+              type="submit"
+              disabled={!canPost}
+              onClick={post}
+              className="px-5 font-semibold shadow-sm"
+            >
               {posting && <LoaderCircle className="animate-spin" />}
               {parentStuff ? (highlightedText ? t('Publish Highlight') : t('Reply')) : t('Post')}
             </Button>
           </div>
         </div>
       </div>
-      <PostOptions
-        posting={posting}
-        show={showMoreOptions}
-        addClientTag={addClientTag}
-        setAddClientTag={setAddClientTag}
-        isNsfw={isNsfw}
-        setIsNsfw={setIsNsfw}
-        minPow={minPow}
-        setMinPow={setMinPow}
-      />
-      <div className="flex items-center justify-around gap-2 sm:hidden">
-        <Button
-          className="w-full"
-          variant="secondary"
-          onClick={(e) => {
-            e.stopPropagation()
-            close()
-          }}
-        >
-          {t('Cancel')}
-        </Button>
-        <Button className="w-full" type="submit" disabled={!canPost} onClick={post}>
-          {posting && <LoaderCircle className="animate-spin" />}
-          {parentStuff ? t('Reply') : t('Post')}
-        </Button>
-      </div>
+
+      {showMoreOptions && (
+        <>
+          <div className="h-px bg-border" />
+          <div className="px-5 py-3 sm:px-6">
+            <PostOptions
+              posting={posting}
+              show={showMoreOptions}
+              addClientTag={addClientTag}
+              setAddClientTag={setAddClientTag}
+              isNsfw={isNsfw}
+              setIsNsfw={setIsNsfw}
+              minPow={minPow}
+              setMinPow={setMinPow}
+            />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/PostEditor/PostRelaySelector.tsx
+++ b/src/components/PostEditor/PostRelaySelector.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { isProtectedEvent } from '@/lib/event'
 import { simplifyUrl } from '@/lib/url'
@@ -15,7 +14,7 @@ import { useCurrentRelays } from '@/providers/CurrentRelaysProvider'
 import { useFavoriteRelays } from '@/providers/FavoriteRelaysProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import client from '@/services/client.service'
-import { Check } from 'lucide-react'
+import { Check, ChevronDown, Radio } from 'lucide-react'
 import { NostrEvent } from 'nostr-tools'
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -205,19 +204,23 @@ export default function PostRelaySelector({
     )
   }, [postTargetItems, relaySets, selectableRelays])
 
+  const triggerClass =
+    'h-9 min-w-0 max-w-full gap-1.5 px-2.5 text-sm font-normal text-muted-foreground hover:text-foreground'
+
   if (isSmallScreen) {
     return (
       <>
-        <div className="flex items-center gap-2">
-          <Label className="shrink-0">{t('Post to')}</Label>
-          <Button
-            variant="outline"
-            className="min-w-0 max-w-fit justify-start px-2"
-            onClick={() => setIsDrawerOpen(true)}
-          >
-            <div className="truncate">{description}</div>
-          </Button>
-        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          title={t('Post to')}
+          className={triggerClass}
+          onClick={() => setIsDrawerOpen(true)}
+        >
+          <Radio className="size-4 shrink-0" />
+          <span className="truncate">{description}</span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+        </Button>
         <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
           <DrawerContent title={t('Post to')} className="max-h-[80dvh]">
             <div className="overflow-y-auto overscroll-contain py-2">{content}</div>
@@ -229,14 +232,13 @@ export default function PostRelaySelector({
 
   return (
     <DropdownMenu>
-      <div className="flex items-center gap-2">
-        <Label className="shrink-0">{t('Post to')}</Label>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="min-w-0 max-w-fit justify-start px-2">
-            <div className="truncate">{description}</div>
-          </Button>
-        </DropdownMenuTrigger>
-      </div>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" title={t('Post to')} className={triggerClass}>
+          <Radio className="size-4 shrink-0" />
+          <span className="truncate">{description}</span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="max-h-[50vh] max-w-96" showScrollButtons>
         {content}
       </DropdownMenuContent>

--- a/src/components/PostEditor/PostTextarea/Preview.tsx
+++ b/src/components/PostEditor/PostTextarea/Preview.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@/components/ui/card'
 import { transformCustomEmojisInContent } from '@/lib/draft-event'
 import { createFakeEvent } from '@/lib/event'
 import { cn } from '@/lib/utils'
@@ -11,12 +10,12 @@ export default function Preview({ content, className }: { content: string; class
     [content]
   )
   return (
-    <Card className={cn('p-3', className)}>
+    <div className={cn('px-5 py-2 text-base sm:px-6', className)}>
       <Content
         event={createFakeEvent({ content: processedContent, tags: emojiTags })}
         className="pointer-events-none h-full"
         mustLoadMedia
       />
-    </Card>
+    </div>
   )
 }

--- a/src/components/PostEditor/PostTextarea/index.tsx
+++ b/src/components/PostEditor/PostTextarea/index.tsx
@@ -41,6 +41,7 @@ const PostTextarea = forwardRef<
     onUploadProgress?: (file: File, progress: number) => void
     onUploadEnd?: (file: File) => void
     placeholder?: string
+    topRightActions?: React.ReactNode
   }
 >(
   (
@@ -54,7 +55,8 @@ const PostTextarea = forwardRef<
       onUploadStart,
       onUploadProgress,
       onUploadEnd,
-      placeholder
+      placeholder,
+      topRightActions
     },
     ref
   ) => {
@@ -88,10 +90,7 @@ const PostTextarea = forwardRef<
       ],
       editorProps: {
         attributes: {
-          class: cn(
-            'border rounded-lg p-3 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring',
-            className
-          )
+          class: cn('px-5 py-2 text-base focus-visible:outline-hidden sm:px-6', className)
         },
         handleKeyDown: (_view, event) => {
           // Handle Ctrl+Enter or Cmd+Enter for submit
@@ -162,21 +161,30 @@ const PostTextarea = forwardRef<
     }
 
     return (
-      <Tabs
-        defaultValue="edit"
-        value={tabValue}
-        onValueChange={(v) => setTabValue(v)}
-        className="space-y-2"
-      >
-        <TabsList>
-          <TabsTrigger value="edit">{t('Edit')}</TabsTrigger>
-          <TabsTrigger value="preview">{t('Preview')}</TabsTrigger>
-        </TabsList>
-        <TabsContent value="edit">
+      <Tabs defaultValue="edit" value={tabValue} onValueChange={(v) => setTabValue(v)}>
+        <div className="flex items-center gap-2 px-5 pt-3 sm:px-6">
+          <TabsList className="h-auto gap-1 bg-transparent p-0">
+            <TabsTrigger
+              value="edit"
+              className="h-8 rounded-md bg-transparent px-2.5 text-sm text-muted-foreground shadow-none hover:text-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            >
+              {t('Edit')}
+            </TabsTrigger>
+            <TabsTrigger
+              value="preview"
+              className="h-8 rounded-md bg-transparent px-2.5 text-sm text-muted-foreground shadow-none hover:text-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            >
+              {t('Preview')}
+            </TabsTrigger>
+          </TabsList>
+          {topRightActions && <div className="ms-auto sm:hidden">{topRightActions}</div>}
+        </div>
+        <TabsContent value="edit" className="mt-0">
           <EditorContent className="tiptap" editor={editor} />
         </TabsContent>
         <TabsContent
           value="preview"
+          className="mt-0"
           onClick={() => {
             setTabValue('edit')
             editor.commands.focus()

--- a/src/components/PostEditor/index.tsx
+++ b/src/components/PostEditor/index.tsx
@@ -5,14 +5,8 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { Drawer, DrawerContent } from '@/components/ui/drawer'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle
-} from '@/components/ui/sheet'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import postEditor from '@/services/post-editor.service'
 import { Event } from 'nostr-tools'
@@ -53,11 +47,10 @@ export default function PostEditor({
 
   if (isSmallScreen) {
     return (
-      <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent
-          className="h-full w-full border-none p-0"
-          side="bottom"
-          hideClose
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent
+          className="h-dvh max-h-dvh overflow-hidden"
+          title={highlightedText ? t('Create Highlight') : t('New Note')}
           onEscapeKeyDown={(e) => {
             if (postEditor.isSuggestionPopupOpen) {
               e.preventDefault()
@@ -65,26 +58,16 @@ export default function PostEditor({
             }
           }}
         >
-          <ScrollArea className="h-full max-h-screen px-4">
-            <div className="space-y-4 px-2 py-6">
-              <SheetHeader>
-                <SheetTitle className="text-start">
-                  {highlightedText ? t('Create Highlight') : <Title parentStuff={parentStuff} />}
-                </SheetTitle>
-                <SheetDescription className="hidden" />
-              </SheetHeader>
-              {content}
-            </div>
-          </ScrollArea>
-        </SheetContent>
-      </Sheet>
+          <ScrollArea className="min-h-0 flex-1">{content}</ScrollArea>
+        </DrawerContent>
+      </Drawer>
     )
   }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="max-w-2xl p-0"
+        className="max-w-2xl p-0 sm:rounded-2xl"
         withoutClose
         onEscapeKeyDown={(e) => {
           if (postEditor.isSuggestionPopupOpen) {
@@ -93,16 +76,14 @@ export default function PostEditor({
           }
         }}
       >
-        <ScrollArea className="h-full max-h-screen px-4">
-          <div className="space-y-4 px-2 py-6">
-            <DialogHeader>
-              <DialogTitle>
-                {highlightedText ? t('Create Highlight') : <Title parentStuff={parentStuff} />}
-              </DialogTitle>
-              <DialogDescription className="hidden" />
-            </DialogHeader>
-            {content}
-          </div>
+        <ScrollArea className="h-full max-h-[85vh]">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle>
+              {highlightedText ? t('Create Highlight') : <Title parentStuff={parentStuff} />}
+            </DialogTitle>
+            <DialogDescription className="hidden" />
+          </DialogHeader>
+          {content}
         </ScrollArea>
       </DialogContent>
     </Dialog>

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -973,6 +973,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'قد لا تظهر الاستطلاعات على العملاء الذين لا يدعمونها.',
     'Show thread context': 'إظهار سياق المحادثة',
-    'Hide thread context': 'إخفاء سياق المحادثة'
+    'Hide thread context': 'إخفاء سياق المحادثة',
+    Enable: 'تفعيل',
+    Upload: 'رفع'
   }
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1005,6 +1005,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Umfragen werden möglicherweise nicht auf Clients angezeigt, die sie nicht unterstützen.',
     'Show thread context': 'Thread-Kontext anzeigen',
-    'Hide thread context': 'Thread-Kontext ausblenden'
+    'Hide thread context': 'Thread-Kontext ausblenden',
+    Enable: 'Aktivieren',
+    Upload: 'Hochladen'
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1007,6 +1007,7 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Polls may not display on clients that don’t support them.',
     'Show thread context': 'Show thread context',
-    'Hide thread context': 'Hide thread context'
+    'Hide thread context': 'Hide thread context',
+    Enable: 'Enable'
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1008,6 +1008,7 @@ export default {
       'Polls may not display on clients that don’t support them.',
     'Show thread context': 'Show thread context',
     'Hide thread context': 'Hide thread context',
-    Enable: 'Enable'
+    Enable: 'Enable',
+    Upload: 'Upload'
   }
 }

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -994,6 +994,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Es posible que las encuestas no se muestren en clientes que no las admiten.',
     'Show thread context': 'Mostrar contexto del hilo',
-    'Hide thread context': 'Ocultar contexto del hilo'
+    'Hide thread context': 'Ocultar contexto del hilo',
+    Enable: 'Activar',
+    Upload: 'Subir'
   }
 }

--- a/src/i18n/locales/fa.ts
+++ b/src/i18n/locales/fa.ts
@@ -989,6 +989,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'نظرسنجی‌ها ممکن است در کلاینت‌هایی که از آن‌ها پشتیبانی نمی‌کنند نمایش داده نشوند.',
     'Show thread context': 'نمایش بافت گفت‌وگو',
-    'Hide thread context': 'پنهان کردن بافت گفت‌وگو'
+    'Hide thread context': 'پنهان کردن بافت گفت‌وگو',
+    Enable: 'فعال‌سازی',
+    Upload: 'بارگذاری'
   }
 }

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1003,6 +1003,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Les sondages peuvent ne pas s’afficher sur les clients qui ne les prennent pas en charge.',
     'Show thread context': 'Afficher le contexte du fil',
-    'Hide thread context': 'Masquer le contexte du fil'
+    'Hide thread context': 'Masquer le contexte du fil',
+    Enable: 'Activer',
+    Upload: 'Téléverser'
   }
 }

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -989,6 +989,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'पोल उन क्लाइंट पर प्रदर्शित नहीं हो सकते जो इनका समर्थन नहीं करते।',
     'Show thread context': 'थ्रेड संदर्भ दिखाएं',
-    'Hide thread context': 'थ्रेड संदर्भ छिपाएं'
+    'Hide thread context': 'थ्रेड संदर्भ छिपाएं',
+    Enable: 'सक्षम करें',
+    Upload: 'अपलोड'
   }
 }

--- a/src/i18n/locales/hu.ts
+++ b/src/i18n/locales/hu.ts
@@ -989,6 +989,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'A szavazások előfordulhat, hogy nem jelennek meg azokon a klienseken, amelyek nem támogatják őket.',
     'Show thread context': 'Beszélgetés kontextusának megjelenítése',
-    'Hide thread context': 'Beszélgetés kontextusának elrejtése'
+    'Hide thread context': 'Beszélgetés kontextusának elrejtése',
+    Enable: 'Engedélyezés',
+    Upload: 'Feltöltés'
   }
 }

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -994,6 +994,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'I sondaggi potrebbero non essere visualizzati sui client che non li supportano.',
     'Show thread context': 'Mostra contesto del thread',
-    'Hide thread context': 'Nascondi contesto del thread'
+    'Hide thread context': 'Nascondi contesto del thread',
+    Enable: 'Abilita',
+    Upload: 'Carica'
   }
 }

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -990,6 +990,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       '投票機能に対応していないクライアントでは表示されない場合があります。',
     'Show thread context': 'スレッドの文脈を表示',
-    'Hide thread context': 'スレッドの文脈を非表示'
+    'Hide thread context': 'スレッドの文脈を非表示',
+    Enable: '有効化',
+    Upload: 'アップロード'
   }
 }

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -979,6 +979,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       '투표를 지원하지 않는 클라이언트에서는 표시되지 않을 수 있습니다.',
     'Show thread context': '스레드 맥락 보기',
-    'Hide thread context': '스레드 맥락 숨기기'
+    'Hide thread context': '스레드 맥락 숨기기',
+    Enable: '사용',
+    Upload: '업로드'
   }
 }

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -997,6 +997,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Ankiety mogą nie być wyświetlane w klientach, które ich nie obsługują.',
     'Show thread context': 'Pokaż kontekst wątku',
-    'Hide thread context': 'Ukryj kontekst wątku'
+    'Hide thread context': 'Ukryj kontekst wątku',
+    Enable: 'Włącz',
+    Upload: 'Prześlij'
   }
 }

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -993,6 +993,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'As enquetes podem não ser exibidas em clientes que não as suportam.',
     'Show thread context': 'Mostrar contexto da conversa',
-    'Hide thread context': 'Ocultar contexto da conversa'
+    'Hide thread context': 'Ocultar contexto da conversa',
+    Enable: 'Ativar',
+    Upload: 'Enviar'
   }
 }

--- a/src/i18n/locales/pt-PT.ts
+++ b/src/i18n/locales/pt-PT.ts
@@ -996,6 +996,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'As sondagens podem não ser apresentadas em clientes que não as suportem.',
     'Show thread context': 'Mostrar contexto da conversa',
-    'Hide thread context': 'Ocultar contexto da conversa'
+    'Hide thread context': 'Ocultar contexto da conversa',
+    Enable: 'Ativar',
+    Upload: 'Carregar'
   }
 }

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -995,6 +995,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Опросы могут не отображаться в клиентах, которые их не поддерживают.',
     'Show thread context': 'Показать контекст треда',
-    'Hide thread context': 'Скрыть контекст треда'
+    'Hide thread context': 'Скрыть контекст треда',
+    Enable: 'Включить',
+    Upload: 'Загрузить'
   }
 }

--- a/src/i18n/locales/th.ts
+++ b/src/i18n/locales/th.ts
@@ -972,6 +972,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'โพลอาจไม่แสดงบนไคลเอนต์ที่ไม่รองรับ',
     'Show thread context': 'แสดงบริบทของเธรด',
-    'Hide thread context': 'ซ่อนบริบทของเธรด'
+    'Hide thread context': 'ซ่อนบริบทของเธรด',
+    Enable: 'เปิดใช้งาน',
+    Upload: 'อัปโหลด'
   }
 }

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -995,6 +995,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       'Anketler, onları desteklemeyen istemcilerde görüntülenmeyebilir.',
     'Show thread context': 'Konu bağlamını göster',
-    'Hide thread context': 'Konu bağlamını gizle'
+    'Hide thread context': 'Konu bağlamını gizle',
+    Enable: 'Etkinleştir',
+    Upload: 'Yükle'
   }
 }

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -949,6 +949,8 @@ export default {
     'Polls may not display on clients that don’t support them.':
       '不支援投票的客戶端可能無法顯示此投票。',
     'Show thread context': '展開對話上下文',
-    'Hide thread context': '收起對話上下文'
+    'Hide thread context': '收起對話上下文',
+    Enable: '啟用',
+    Upload: '上傳'
   }
 }

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -957,6 +957,7 @@ export default {
       '不支持投票的客户端可能无法显示此投票。',
     'Show thread context': '展开对话上下文',
     'Hide thread context': '收起对话上下文',
-    Enable: '启用'
+    Enable: '启用',
+    Upload: '上传'
   }
 }

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -956,6 +956,7 @@ export default {
     'Polls may not display on clients that don’t support them.':
       '不支持投票的客户端可能无法显示此投票。',
     'Show thread context': '展开对话上下文',
-    'Hide thread context': '收起对话上下文'
+    'Hide thread context': '收起对话上下文',
+    Enable: '启用'
   }
 }


### PR DESCRIPTION
## Summary
- Reshape PostEditor so the Dialog/Drawer surface *is* the card — hairline-divided sections replace the nested `rounded-2xl` wrapper that made it feel like "a card inside a card".
- Compose UI now matches modern patterns: mobile uses `Drawer` (full dvh) with Post button sharing the Tabs row; desktop keeps the toolbar but drops Cancel/title duplication.
- Publish options (`Protected` + `Post to`) move to a Twitter-style row directly under the textarea; Protected is a chip with a `?` popover, active state is emerald.
- Poll editor becomes a self-contained Twitter-style card with internal hairlines, sm:grid-cols-2 settings layout, and a bottom destructive Remove button.

## Key changes
- `PostEditor/index.tsx` — `Sheet` → `Drawer` on mobile (`h-dvh max-h-dvh overflow-hidden`); cleaner `DialogHeader` on desktop.
- `PostContent.tsx` — collapse inner card wrapper; reorder regions; integrate mobile Post button via `PostTextarea.topRightActions`; remove `Cancel` chrome on mobile.
- `PostTextarea/index.tsx` — Tabs+`topRightActions` flex row; transparent TabsList; `text-sm` triggers.
- `PostRelaySelector.tsx` — chip form (`Radio` + description + `ChevronDown`), `min-w-0 max-w-full` for fill-and-truncate behavior.
- `PollEditor.tsx` — rounded-2xl card; `inputClass` shared with textarea/preview style; settings `grid sm:grid-cols-2`; full-width destructive remove button at the bottom.
- New `ParentEventPreview.tsx` — top/bottom fade overlays toggled by scroll position via `ResizeObserver`.
- `i18n/locales/{en,zh}.ts` — add `Enable / 启用`.

## Test plan
- [ ] Desktop: open editor with and without a parent event; verify hairlines, padding alignment, Post relay chip truncation, Protected chip + popover, Settings panel under toolbar.
- [ ] Desktop: long parent event → verify ParentEventPreview top/bottom fades appear/disappear with scroll.
- [ ] Mobile (Drawer): swipe-to-close; Post button on Tabs row; Mentions/Cancel removed from chrome; PollEditor card layout.
- [ ] Poll: toggle on, fill options, switch "Allow multiple choices" and pick End date — both on a single row on `sm:` and stacked on mobile.
- [ ] Protected: click chip toggles without dialog; click `?` shows hint popover.
- [ ] Cmd/Ctrl+Enter still submits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)