### PR TITLE
Confirm before exiting Jumble with back button

### DIFF
--- a/src/PageManager.tsx
+++ b/src/PageManager.tsx
@@ -82,6 +82,11 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
   const { themeSetting } = useTheme()
   const { enableSingleColumnLayout, sidebarCollapse } = useUserPreferences()
   const ignorePopStateRef = useRef(false)
+  const secondaryStackRef = useRef<TStackItem[]>([])
+
+  useEffect(() => {
+    secondaryStackRef.current = secondaryStack
+  }, [secondaryStack])
 
   useEffect(() => {
     if (isSmallScreen) return
@@ -158,6 +163,19 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
       if (closeModal) {
         ignorePopStateRef.current = true
         window.history.forward()
+        return
+      }
+
+      if (
+        !e.state &&
+        window.location.pathname + window.location.search + window.location.hash === '/' &&
+        secondaryStackRef.current.length === 0
+      ) {
+        const shouldClose = window.confirm('Close Jumble?')
+        if (!shouldClose) {
+          ignorePopStateRef.current = true
+          window.history.forward()
+        }
         return
       }
 


### PR DESCRIPTION
Closes #128.

## Summary
- confirm before leaving Jumble from the root route when Android/browser back would exit the app
- keep normal back behavior for modals and secondary pages
- restore the current history entry when the user cancels the close action

## Tests
- git diff --check

Note: I could not run the npm test suite in this environment because npm is not available on PATH.