### PR TITLE
Feat/post author picker

### DIFF
--- a/src/components/PostEditor/AuthorPicker.tsx
+++ b/src/components/PostEditor/AuthorPicker.tsx
@@ -6,16 +6,20 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { isSameAccount } from '@/lib/account'
 import { formatPubkey } from '@/lib/pubkey'
 import { cn } from '@/lib/utils'
-import { useNostr } from '@/providers/NostrProvider'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useNostr } from '@/providers/NostrProvider'
+import { TAccountPointer } from '@/types'
 import { Check, ChevronDown, CircleHelp, VenetianMask } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { SimpleUserAvatar } from '../UserAvatar'
 import { SimpleUsername } from '../Username'
 
-export type TAuthorChoice = 'self' | 'anonymous'
+export type TAuthorChoice =
+  | { kind: 'account'; account: TAccountPointer }
+  | { kind: 'anonymous' }
 
 export default function AuthorPicker({
   value,
@@ -25,7 +29,13 @@ export default function AuthorPicker({
   onChange: (choice: TAuthorChoice) => void
 }) {
   const { t } = useTranslation()
-  const { account } = useNostr()
+  const { accounts } = useNostr()
+
+  // npub accounts are read-only and can't sign — hide them entirely from the
+  // picker so a user can't pick a dead-end choice. Author overrides are purely
+  // local to this draft; selecting a different account never touches the
+  // active session.
+  const signableAccounts = accounts.filter((a) => a.signerType !== 'npub')
 
   return (
     <DropdownMenu>
@@ -37,10 +47,10 @@ export default function AuthorPicker({
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.preventDefault()}
         >
-          {value === 'anonymous' || !account ? (
+          {value.kind === 'anonymous' ? (
             <AnonymousAvatar />
           ) : (
-            <SimpleUserAvatar userId={account.pubkey} size="small" ignorePolicy />
+            <SimpleUserAvatar userId={value.account.pubkey} size="small" ignorePolicy />
           )}
           <ChevronDown className="size-3.5 text-muted-foreground" />
         </button>
@@ -53,25 +63,35 @@ export default function AuthorPicker({
         <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
           {t('Posting as')}
         </DropdownMenuLabel>
-        {account && (
-          <DropdownMenuItem onSelect={() => onChange('self')} className="gap-2">
-            <SimpleUserAvatar userId={account.pubkey} size="small" ignorePolicy />
-            <div className="min-w-0 flex-1">
-              <SimpleUsername
-                userId={account.pubkey}
-                className="block truncate text-sm font-medium"
-              />
-              <div className="truncate text-xs text-muted-foreground">
-                {formatPubkey(account.pubkey)}
+        {signableAccounts.map((act) => {
+          const isPicked = value.kind === 'account' && isSameAccount(value.account, act)
+          return (
+            <DropdownMenuItem
+              key={`${act.pubkey}-${act.signerType}`}
+              onSelect={() => onChange({ kind: 'account', account: act })}
+              className="gap-2"
+            >
+              <SimpleUserAvatar userId={act.pubkey} size="small" ignorePolicy />
+              <div className="min-w-0 flex-1">
+                <SimpleUsername
+                  userId={act.pubkey}
+                  className="block truncate text-sm font-medium"
+                />
+                <div className="truncate text-xs text-muted-foreground">
+                  {formatPubkey(act.pubkey)}
+                </div>
               </div>
-            </div>
-            {value === 'self' && (
-              <Check className="size-4 shrink-0 text-primary" aria-label={t('Selected')} />
-            )}
-          </DropdownMenuItem>
-        )}
-        {account && <DropdownMenuSeparator />}
-        <DropdownMenuItem onSelect={() => onChange('anonymous')} className="gap-2">
+              {isPicked && (
+                <Check className="size-4 shrink-0 text-primary" aria-label={t('Selected')} />
+              )}
+            </DropdownMenuItem>
+          )
+        })}
+        {signableAccounts.length > 0 && <DropdownMenuSeparator />}
+        <DropdownMenuItem
+          onSelect={() => onChange({ kind: 'anonymous' })}
+          className="gap-2"
+        >
           <AnonymousAvatar />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1">
@@ -107,7 +127,7 @@ export default function AuthorPicker({
               {t('Post with a one-off ephemeral key')}
             </div>
           </div>
-          {value === 'anonymous' && (
+          {value.kind === 'anonymous' && (
             <Check className="size-4 shrink-0 text-primary" aria-label={t('Selected')} />
           )}
         </DropdownMenuItem>

--- a/src/components/PostEditor/AuthorPicker.tsx
+++ b/src/components/PostEditor/AuthorPicker.tsx
@@ -9,7 +9,8 @@ import {
 import { formatPubkey } from '@/lib/pubkey'
 import { cn } from '@/lib/utils'
 import { useNostr } from '@/providers/NostrProvider'
-import { Check, ChevronDown, VenetianMask } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Check, ChevronDown, CircleHelp, VenetianMask } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { SimpleUserAvatar } from '../UserAvatar'
 import { SimpleUsername } from '../Username'
@@ -73,7 +74,35 @@ export default function AuthorPicker({
         <DropdownMenuItem onSelect={() => onChange('anonymous')} className="gap-2">
           <AnonymousAvatar />
           <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-medium">{t('Anonymous')}</div>
+            <div className="flex items-center gap-1">
+              <span className="truncate text-sm font-medium">{t('Anonymous')}</span>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t('What does Anonymous mean?')}
+                    className="text-muted-foreground hover:text-foreground"
+                    // Don't let opening the explainer also select the item.
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                    }}
+                    onMouseDown={(e) => e.preventDefault()}
+                  >
+                    <CircleHelp className="size-3.5" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  side="right"
+                  className="max-w-xs text-xs leading-relaxed"
+                >
+                  {t(
+                    "Anonymous hides your signing key — every post gets a fresh, unstored key. It does NOT hide your IP or your relay connections. To minimise leaks, anonymous posts go to a generic public relay set (and, for replies, to relays where the thread already lives) rather than your customized default relays. The Jumble client tag is suppressed."
+                  )}
+                </PopoverContent>
+              </Popover>
+            </div>
             <div className="truncate text-xs text-muted-foreground">
               {t('Post with a one-off ephemeral key')}
             </div>

--- a/src/components/PostEditor/AuthorPicker.tsx
+++ b/src/components/PostEditor/AuthorPicker.tsx
@@ -1,0 +1,100 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { formatPubkey } from '@/lib/pubkey'
+import { cn } from '@/lib/utils'
+import { useNostr } from '@/providers/NostrProvider'
+import { Check, ChevronDown, VenetianMask } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { SimpleUserAvatar } from '../UserAvatar'
+import { SimpleUsername } from '../Username'
+
+export type TAuthorChoice = 'self' | 'anonymous'
+
+export default function AuthorPicker({
+  value,
+  onChange
+}: {
+  value: TAuthorChoice
+  onChange: (choice: TAuthorChoice) => void
+}) {
+  const { t } = useTranslation()
+  const { account } = useNostr()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={t('Posting as')}
+          className="clickable flex h-8 shrink-0 items-center gap-1 rounded-full p-0.5 transition-colors hover:bg-accent"
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {value === 'anonymous' || !account ? (
+            <AnonymousAvatar />
+          ) : (
+            <SimpleUserAvatar userId={account.pubkey} size="small" ignorePolicy />
+          )}
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="min-w-64 max-w-80"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+          {t('Posting as')}
+        </DropdownMenuLabel>
+        {account && (
+          <DropdownMenuItem onSelect={() => onChange('self')} className="gap-2">
+            <SimpleUserAvatar userId={account.pubkey} size="small" ignorePolicy />
+            <div className="min-w-0 flex-1">
+              <SimpleUsername
+                userId={account.pubkey}
+                className="block truncate text-sm font-medium"
+              />
+              <div className="truncate text-xs text-muted-foreground">
+                {formatPubkey(account.pubkey)}
+              </div>
+            </div>
+            {value === 'self' && (
+              <Check className="size-4 shrink-0 text-primary" aria-label={t('Selected')} />
+            )}
+          </DropdownMenuItem>
+        )}
+        {account && <DropdownMenuSeparator />}
+        <DropdownMenuItem onSelect={() => onChange('anonymous')} className="gap-2">
+          <AnonymousAvatar />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{t('Anonymous')}</div>
+            <div className="truncate text-xs text-muted-foreground">
+              {t('Post with a one-off ephemeral key')}
+            </div>
+          </div>
+          {value === 'anonymous' && (
+            <Check className="size-4 shrink-0 text-primary" aria-label={t('Selected')} />
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function AnonymousAvatar() {
+  return (
+    <div
+      className={cn(
+        'flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground'
+      )}
+    >
+      <VenetianMask className="size-4" />
+    </div>
+  )
+}

--- a/src/components/PostEditor/Mentions.tsx
+++ b/src/components/PostEditor/Mentions.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { useMuteList } from '@/providers/MuteListProvider'
-import { useNostr } from '@/providers/NostrProvider'
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import client from '@/services/client.service'
 import { Check } from 'lucide-react'
@@ -22,17 +21,22 @@ export default function Mentions({
   content,
   mentions,
   setMentions,
-  parentEvent
+  parentEvent,
+  authorPubkey
 }: {
   content: string
   mentions: string[]
   setMentions: (mentions: string[]) => void
   parentEvent?: Event
+  // The pubkey this draft will be signed with. The picker filters this out of
+  // suggested mentions ("can't mention yourself"). Passing `undefined` — e.g.
+  // for an anonymous draft, where the author is an ephemeral key and the
+  // logged-in user is a legitimate mention target — disables that filter.
+  authorPubkey?: string
 }) {
   const { t } = useTranslation()
   const { isSmallScreen } = useScreenSize()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const { pubkey } = useNostr()
   const { mutePubkeySet } = useMuteList()
   const [potentialMentions, setPotentialMentions] = useState<string[]>([])
   const [parentEventPubkey, setParentEventPubkey] = useState<string | undefined>()
@@ -40,9 +44,12 @@ export default function Mentions({
 
   useEffect(() => {
     extractMentions(content, parentEvent).then(({ pubkeys, relatedPubkeys, parentEventPubkey }) => {
-      const _parentEventPubkey = parentEventPubkey !== pubkey ? parentEventPubkey : undefined
+      const _parentEventPubkey =
+        parentEventPubkey !== authorPubkey ? parentEventPubkey : undefined
       setParentEventPubkey(_parentEventPubkey)
-      const potentialMentions = [...pubkeys, ...relatedPubkeys].filter((p) => p !== pubkey)
+      const potentialMentions = [...pubkeys, ...relatedPubkeys].filter(
+        (p) => p !== authorPubkey
+      )
       if (_parentEventPubkey) {
         potentialMentions.push(_parentEventPubkey)
       }
@@ -59,7 +66,7 @@ export default function Mentions({
         )
       })
     })
-  }, [content, parentEvent, pubkey, mutePubkeySet])
+  }, [content, parentEvent, authorPubkey, mutePubkeySet])
 
   useEffect(() => {
     const newMentions = potentialMentions.filter((pubkey) => !removedPubkeys.includes(pubkey))

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -81,9 +81,24 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
   ref
 ) {
   const { t } = useTranslation()
-  const { pubkey, checkLogin, account, signer } = useNostr()
+  const { pubkey, checkLogin, account, buildSignerForAccount } = useNostr()
 
-  const [authorChoice, setAuthorChoice] = useState<TAuthorChoice>('self')
+  const [authorChoice, setAuthorChoice] = useState<TAuthorChoice>(() =>
+    account ? { kind: 'account', account } : { kind: 'anonymous' }
+  )
+  const authorChoiceTouchedRef = useRef(false)
+  const handleAuthorChoiceChange = useCallback((choice: TAuthorChoice) => {
+    authorChoiceTouchedRef.current = true
+    setAuthorChoice(choice)
+  }, [])
+  // If the editor mounted before login (so we defaulted to anonymous), latch
+  // on to the account once it appears — but only if the user hasn't already
+  // picked something explicitly. Picking another account or Anonymous is a
+  // per-post override and must never be reverted automatically.
+  useEffect(() => {
+    if (authorChoiceTouchedRef.current) return
+    if (account) setAuthorChoice({ kind: 'account', account })
+  }, [account])
   // Ephemeral signer, lazily built on first use and reused across re-renders so
   // typing doesn't churn a new identity each keystroke. Never persisted.
   const anonymousSignerRef = useRef<TAnonymousSigner | null>(null)
@@ -162,22 +177,22 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
 
   const hasContent = !!text.trim() || (isPoll && pollCreateData.options.some((o) => o.trim()))
 
-  // Anonymous always has a signer (we generate one on the fly), so a logged-out
-  // user can still ship an anonymous post. Otherwise we need a logged-in
-  // account capable of signing.
-  const isAnonymous = authorChoice === 'anonymous'
+  const isAnonymous = authorChoice.kind === 'anonymous'
+  // The picked author must be capable of signing. Anonymous always can (we
+  // generate the key on the spot); a stored account can iff its signerType
+  // isn't 'npub' (read-only). Independent of session state — a logged-out
+  // user can still ship an anonymous post.
+  const authorCanSign = isAnonymous || authorChoice.account.signerType !== 'npub'
   const canPost = useMemo(() => {
     return (
-      (isAnonymous || (!!pubkey && account?.signerType !== 'npub')) &&
+      authorCanSign &&
       (!!text || !!highlightedText) &&
       !uploadProgresses.length &&
       (!isPoll || pollCreateData.options.filter((option) => !!option.trim()).length >= 2) &&
       (!isProtectedEvent || additionalRelayUrls.length > 0)
     )
   }, [
-    isAnonymous,
-    pubkey,
-    account,
+    authorCanSign,
     text,
     highlightedText,
     uploadProgresses,
@@ -332,22 +347,31 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
   // editor produces an author-free TDraftEvent (no pubkey/id/sig); the signer
   // fills those in. So per-post author overrides are just a matter of swapping
   // which ISigner runs at sign time — nothing else in the post flow changes.
-  const resolveAuthorSigner = (): { signer: ISigner; pubkey: string } | null => {
-    if (authorChoice === 'anonymous') return getAnonymousSigner()
-    if (!signer || !pubkey) return null
-    return { signer, pubkey }
+  const resolveAuthorSigner = async (): Promise<{ signer: ISigner; pubkey: string }> => {
+    if (authorChoice.kind === 'anonymous') {
+      return getAnonymousSigner()
+    }
+    const oneOff = await buildSignerForAccount(authorChoice.account)
+    return { signer: oneOff, pubkey: authorChoice.account.pubkey }
   }
+
+  // The draft queue is per-account: enqueueing under a different pubkey would
+  // surface a foreign signed event in the active user's drafts box and let
+  // them "retry" something they didn't author. So only the active account's
+  // posts go through it; anonymous and other-account posts publish directly.
+  const isCurrentAccountAuthor =
+    authorChoice.kind === 'account' &&
+    !!account &&
+    authorChoice.account.pubkey === account.pubkey
 
   const post = async (e?: React.MouseEvent) => {
     e?.stopPropagation()
     const runPost = async () => {
       if (!canPost || postingRef.current) return
-      const resolved = resolveAuthorSigner()
-      if (!resolved) return
-      const { signer: authorSigner, pubkey: authorPubkey } = resolved
-
       postingRef.current = true
       try {
+        const { signer: authorSigner, pubkey: authorPubkey } = await resolveAuthorSigner()
+
         const draftEvent = await createDraftEvent({
           parentStuff: initialParentStuff,
           highlightedText,
@@ -394,13 +418,7 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
         deleteDraftEventCache(draftEvent)
         const targetRelays = await client.determineTargetRelays(signed, publishOptions)
 
-        if (authorChoice === 'anonymous') {
-          // Per-post override: bypass the per-account draft queue. Its records
-          // are keyed to the logged-in pubkey and an ephemeral failure would
-          // otherwise surface in the user's drafts box with a foreign signed
-          // event they can't retry meaningfully.
-          await client.publishEvent(targetRelays, signed)
-        } else {
+        if (isCurrentAccountAuthor) {
           await postDraftService.enqueue({
             id: draftIdRef.current,
             pubkey: authorPubkey,
@@ -412,6 +430,8 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
               typeof initialParentStuff === 'string' ? initialParentStuff : undefined,
             highlightedText
           })
+        } else {
+          await client.publishEvent(targetRelays, signed)
         }
         close()
       } catch (error) {
@@ -424,7 +444,7 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
       }
     }
 
-    if (authorChoice === 'anonymous') {
+    if (authorChoice.kind === 'anonymous') {
       // Anonymous doesn't need a logged-in user — skip the login gate.
       runPost()
     } else {
@@ -482,7 +502,7 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
         onUploadProgress={handleUploadProgress}
         onUploadEnd={handleUploadEnd}
         placeholder={highlightedText ? t('Write your thoughts about this highlight...') : undefined}
-        topLeftActions={<AuthorPicker value={authorChoice} onChange={setAuthorChoice} />}
+        topLeftActions={<AuthorPicker value={authorChoice} onChange={handleAuthorChoiceChange} />}
         topRightActions={
           <div className="flex items-center gap-1">
             <DraftsButton onClick={() => onOpenDrafts?.()} />
@@ -657,10 +677,14 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
             parentEvent={parentEvent}
             mentions={mentions}
             setMentions={setMentions}
-            // Anonymous posts are signed with an ephemeral key, so the
-            // logged-in user is a *legitimate* mention target — don't let
-            // Mentions filter them out.
-            authorPubkey={authorChoice === 'anonymous' ? undefined : pubkey ?? undefined}
+            // Filter the *effective* author out of suggested mentions, not
+            // the logged-in user. Anonymous → undefined so the logged-in user
+            // (a legitimate mention target) is not stripped; posting as
+            // another account → that account's pubkey so it doesn't suggest
+            // self-mention.
+            authorPubkey={
+              authorChoice.kind === 'anonymous' ? undefined : authorChoice.account.pubkey
+            }
           />
           <div className="hidden items-center gap-2 sm:flex">
             <Button

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { createAnonymousSigner, TAnonymousSigner } from '@/lib/anonymous-signer'
 import { formatError } from '@/lib/error'
 import DraftsButton from './DraftsButton'
 import {
@@ -21,11 +22,12 @@ import { useNostr } from '@/providers/NostrProvider'
 import mediaUpload from '@/services/media-upload.service'
 import client from '@/services/client.service'
 import postDraftService from '@/services/post-draft.service'
-import { TPollCreateData, TPostTargetItem } from '@/types'
+import { ISigner, TPollCreateData, TPostTargetItem } from '@/types'
 import { TPostDraftUnsigned } from '@/types/post-draft'
+import AuthorPicker, { TAuthorChoice } from './AuthorPicker'
 import { Content } from '@tiptap/react'
 import { CircleHelp, ImageUp, ListTodo, Lock, Settings, Smile, X } from 'lucide-react'
-import { Event, kinds, VerifiedEvent } from 'nostr-tools'
+import { Event, kinds } from 'nostr-tools'
 import {
   forwardRef,
   useCallback,
@@ -79,7 +81,18 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
   ref
 ) {
   const { t } = useTranslation()
-  const { pubkey, signEvent, checkLogin, account } = useNostr()
+  const { pubkey, checkLogin, account, signer } = useNostr()
+
+  const [authorChoice, setAuthorChoice] = useState<TAuthorChoice>('self')
+  // Ephemeral signer, lazily built on first use and reused across re-renders so
+  // typing doesn't churn a new identity each keystroke. Never persisted.
+  const anonymousSignerRef = useRef<TAnonymousSigner | null>(null)
+  const getAnonymousSigner = () => {
+    if (!anonymousSignerRef.current) {
+      anonymousSignerRef.current = createAnonymousSigner()
+    }
+    return anonymousSignerRef.current
+  }
 
   const initialParentStuff = useMemo<Event | string | undefined>(() => {
     if (initialDraft?.parentEvent) return initialDraft.parentEvent
@@ -149,16 +162,22 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
 
   const hasContent = !!text.trim() || (isPoll && pollCreateData.options.some((o) => o.trim()))
 
+  // Anonymous always has a signer (we generate one on the fly), so a logged-out
+  // user can still ship an anonymous post. Otherwise we need a logged-in
+  // account capable of signing.
+  const isAnonymous = authorChoice === 'anonymous'
   const canPost = useMemo(() => {
     return (
-      !!pubkey &&
+      (isAnonymous || (!!pubkey && account?.signerType !== 'npub')) &&
       (!!text || !!highlightedText) &&
       !uploadProgresses.length &&
       (!isPoll || pollCreateData.options.filter((option) => !!option.trim()).length >= 2) &&
       (!isProtectedEvent || additionalRelayUrls.length > 0)
     )
   }, [
+    isAnonymous,
     pubkey,
+    account,
     text,
     highlightedText,
     uploadProgresses,
@@ -309,11 +328,24 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
 
   const postingRef = useRef(false)
 
+  // Single source of truth for the signer this draft is authored with. The
+  // editor produces an author-free TDraftEvent (no pubkey/id/sig); the signer
+  // fills those in. So per-post author overrides are just a matter of swapping
+  // which ISigner runs at sign time — nothing else in the post flow changes.
+  const resolveAuthorSigner = (): { signer: ISigner; pubkey: string } | null => {
+    if (authorChoice === 'anonymous') return getAnonymousSigner()
+    if (!signer || !pubkey) return null
+    return { signer, pubkey }
+  }
+
   const post = async (e?: React.MouseEvent) => {
     e?.stopPropagation()
-    checkLogin(async () => {
-      if (!canPost || !pubkey || !account || account.signerType === 'npub') return
-      if (postingRef.current) return
+    const runPost = async () => {
+      if (!canPost || postingRef.current) return
+      const resolved = resolveAuthorSigner()
+      if (!resolved) return
+      const { signer: authorSigner, pubkey: authorPubkey } = resolved
+
       postingRef.current = true
       try {
         const draftEvent = await createDraftEvent({
@@ -323,7 +355,7 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
           mentions,
           isPoll,
           pollCreateData,
-          pubkey,
+          pubkey: authorPubkey,
           addClientTag,
           isProtectedEvent,
           isNsfw
@@ -340,32 +372,33 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
           minPow
         }
 
-        let signed: VerifiedEvent
-        if (minPow > 0) {
-          const mined = await minePow({ ...draftEvent, pubkey }, minPow)
-          signed = await signEvent(mined)
-        } else {
-          signed = await signEvent(draftEvent)
-        }
+        const toSign = minPow > 0
+          ? await minePow({ ...draftEvent, pubkey: authorPubkey }, minPow)
+          : draftEvent
+        const signed = await authorSigner.signEvent(toSign)
 
         deleteDraftEventCache(draftEvent)
-
-        // Resolve the concrete relay set now (needs the user's relay context) and
-        // persist it with the draft, so a background/interrupted resend can target
-        // the exact same relays without re-resolving.
         const targetRelays = await client.determineTargetRelays(signed, publishOptions)
 
-        await postDraftService.enqueue({
-          id: draftIdRef.current,
-          pubkey,
-          createdAt: draftCreatedAtRef.current,
-          signedEvent: signed,
-          targetRelays,
-          parentEvent,
-          parentEventCoordinate:
-            typeof initialParentStuff === 'string' ? initialParentStuff : undefined,
-          highlightedText
-        })
+        if (authorChoice === 'anonymous') {
+          // Per-post override: bypass the per-account draft queue. Its records
+          // are keyed to the logged-in pubkey and an ephemeral failure would
+          // otherwise surface in the user's drafts box with a foreign signed
+          // event they can't retry meaningfully.
+          await client.publishEvent(targetRelays, signed)
+        } else {
+          await postDraftService.enqueue({
+            id: draftIdRef.current,
+            pubkey: authorPubkey,
+            createdAt: draftCreatedAtRef.current,
+            signedEvent: signed,
+            targetRelays,
+            parentEvent,
+            parentEventCoordinate:
+              typeof initialParentStuff === 'string' ? initialParentStuff : undefined,
+            highlightedText
+          })
+        }
         close()
       } catch (error) {
         const errors = formatError(error)
@@ -375,7 +408,14 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
       } finally {
         postingRef.current = false
       }
-    })
+    }
+
+    if (authorChoice === 'anonymous') {
+      // Anonymous doesn't need a logged-in user — skip the login gate.
+      runPost()
+    } else {
+      checkLogin(runPost)
+    }
   }
 
   const handlePollToggle = () => {
@@ -428,6 +468,7 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
         onUploadProgress={handleUploadProgress}
         onUploadEnd={handleUploadEnd}
         placeholder={highlightedText ? t('Write your thoughts about this highlight...') : undefined}
+        topLeftActions={<AuthorPicker value={authorChoice} onChange={setAuthorChoice} />}
         topRightActions={
           <div className="flex items-center gap-1">
             <DraftsButton onClick={() => onOpenDrafts?.()} />

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -356,20 +356,34 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
           isPoll,
           pollCreateData,
           pubkey: authorPubkey,
-          addClientTag,
+          // Suppress the NIP-89 client tag on anonymous posts even if the
+          // user has the global toggle on. The tag wouldn't out the signer
+          // directly, but every metadata bit narrows the set of plausible
+          // authors. Anonymous should ship with the minimal fingerprint.
+          addClientTag: isAnonymous ? false : addClientTag,
           isProtectedEvent,
           isNsfw
         })
 
         const _additionalRelayUrls = [...additionalRelayUrls]
-        if (initialParentStuff && typeof initialParentStuff === 'string') {
+        if (initialParentStuff && typeof initialParentStuff === 'string' && !isAnonymous) {
+          // For external-content comments we normally fan out to the user's
+          // default relays. Skip for anonymous — those defaults can leak the
+          // user's customized relay set (paid/account-bound).
           _additionalRelayUrls.push(...getDefaultRelayUrls())
+        }
+        if (isAnonymous && parentEvent) {
+          // "Publish to relays the thread lives on": anonymous replies should
+          // land where the parent event is already visible, not on the
+          // logged-in user's write relays.
+          _additionalRelayUrls.push(...client.getSeenEventRelayUrls(parentEvent.id))
         }
 
         const publishOptions = {
           specifiedRelayUrls: isProtectedEvent ? additionalRelayUrls : undefined,
           additionalRelayUrls: isPoll ? pollCreateData.relays : _additionalRelayUrls,
-          minPow
+          minPow,
+          isAnonymous
         }
 
         const toSign = minPow > 0

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -643,6 +643,10 @@ const PostContent = forwardRef<TPostContentHandle, Props>(function PostContent(
             parentEvent={parentEvent}
             mentions={mentions}
             setMentions={setMentions}
+            // Anonymous posts are signed with an ephemeral key, so the
+            // logged-in user is a *legitimate* mention target — don't let
+            // Mentions filter them out.
+            authorPubkey={authorChoice === 'anonymous' ? undefined : pubkey ?? undefined}
           />
           <div className="hidden items-center gap-2 sm:flex">
             <Button

--- a/src/components/PostEditor/PostTextarea/index.tsx
+++ b/src/components/PostEditor/PostTextarea/index.tsx
@@ -47,6 +47,7 @@ const PostTextarea = forwardRef<
     onUploadProgress?: (file: File, progress: number) => void
     onUploadEnd?: (file: File) => void
     placeholder?: string
+    topLeftActions?: React.ReactNode
     topRightActions?: React.ReactNode
   }
 >(
@@ -61,6 +62,7 @@ const PostTextarea = forwardRef<
       onUploadProgress,
       onUploadEnd,
       placeholder,
+      topLeftActions,
       topRightActions
     },
     ref
@@ -218,7 +220,8 @@ const PostTextarea = forwardRef<
             ref={headerRef}
             className={cn('flex gap-2', stackActions ? 'flex-col-reverse gap-1' : 'items-center')}
           >
-            <div ref={tabsRef} className={stackActions ? 'self-start' : ''}>
+            <div ref={tabsRef} className={cn('flex items-center gap-2', stackActions ? 'self-start' : '')}>
+              {topLeftActions}
               <TabsList className="h-auto gap-1 bg-transparent p-0">
                 <TabsTrigger
                   value="edit"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1022,6 +1022,9 @@ export default {
     Empty: 'Empty',
     'Posting as': 'Posting as',
     Anonymous: 'Anonymous',
-    'Post with a one-off ephemeral key': 'Post with a one-off ephemeral key'
+    'Post with a one-off ephemeral key': 'Post with a one-off ephemeral key',
+    'What does Anonymous mean?': 'What does Anonymous mean?',
+    "Anonymous hides your signing key — every post gets a fresh, unstored key. It does NOT hide your IP or your relay connections. To minimise leaks, anonymous posts go to a generic public relay set (and, for replies, to relays where the thread already lives) rather than your customized default relays. The Jumble client tag is suppressed.":
+      "Anonymous hides your signing key — every post gets a fresh, unstored key. It does NOT hide your IP or your relay connections. To minimise leaks, anonymous posts go to a generic public relay set (and, for replies, to relays where the thread already lives) rather than your customized default relays. The Jumble client tag is suppressed."
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1019,6 +1019,9 @@ export default {
     'Keep editing': 'Keep editing',
     'Open drafts': 'Open drafts',
     'No drafts yet': 'No drafts yet',
-    Empty: 'Empty'
+    Empty: 'Empty',
+    'Posting as': 'Posting as',
+    Anonymous: 'Anonymous',
+    'Post with a one-off ephemeral key': 'Post with a one-off ephemeral key'
   }
 }

--- a/src/lib/anonymous-signer.ts
+++ b/src/lib/anonymous-signer.ts
@@ -1,0 +1,14 @@
+import { NsecSigner } from '@/providers/NostrProvider/nsec.signer'
+import { generateSecretKey } from 'nostr-tools'
+
+export type TAnonymousSigner = {
+  signer: NsecSigner
+  pubkey: string
+}
+
+export function createAnonymousSigner(): TAnonymousSigner {
+  const privkey = generateSecretKey()
+  const signer = new NsecSigner()
+  const pubkey = signer.login(privkey)
+  return { signer, pubkey }
+}

--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -82,6 +82,15 @@ type TNostrContext = {
   attemptDelete: (targetEvent: Event) => Promise<void>
   signHttpAuth: (url: string, method: string) => Promise<string>
   signEvent: (draftEvent: TDraftEvent) => Promise<VerifiedEvent>
+  /**
+   * Build a signer for the given account without changing the active session.
+   * Returns the live signer when the account is already current; otherwise
+   * constructs a one-off signer from stored secrets. Used for per-post author
+   * overrides — picking another account in the editor should not switch the
+   * user out of their current session. Throws for npub (read-only) or when
+   * the account's secrets are not available locally.
+   */
+  buildSignerForAccount: (account: TAccountPointer) => Promise<ISigner>
   nip04Encrypt: (pubkey: string, plainText: string) => Promise<string>
   nip04Decrypt: (pubkey: string, cipherText: string) => Promise<string>
   nip44Encrypt: (pubkey: string, plainText: string) => Promise<string>
@@ -682,6 +691,61 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     return event as VerifiedEvent
   }
 
+  const buildSignerForAccount = async (act: TAccountPointer): Promise<ISigner> => {
+    if (
+      account &&
+      signer &&
+      account.pubkey === act.pubkey &&
+      account.signerType === act.signerType
+    ) {
+      return signer
+    }
+    const full = storage.findAccount(act)
+    if (!full) {
+      throw new Error(t('Account not found'))
+    }
+    switch (full.signerType) {
+      case 'nsec':
+      case 'browser-nsec': {
+        if (!full.nsec) throw new Error(t('No private key stored for this account'))
+        const s = new NsecSigner()
+        s.login(full.nsec)
+        return s
+      }
+      case 'ncryptsec': {
+        if (!full.ncryptsec) throw new Error(t('No encrypted key stored for this account'))
+        const password = await requestPassword()
+        const privkey = nip49.decrypt(full.ncryptsec, password)
+        const s = new NsecSigner()
+        s.login(privkey)
+        return s
+      }
+      case 'bunker': {
+        if (!full.bunker || !full.bunkerClientSecretKey) {
+          throw new Error(t('Bunker connection details missing'))
+        }
+        const s = new BunkerSigner(full.bunkerClientSecretKey)
+        await s.login(full.bunker, false)
+        return s
+      }
+      case 'nip-07': {
+        const s = new Nip07Signer()
+        await s.init()
+        const extPubkey = await s.getPublicKey()
+        if (extPubkey !== act.pubkey) {
+          throw new Error(
+            t('Your browser extension is signed in as a different account')
+          )
+        }
+        return s
+      }
+      case 'npub':
+        throw new Error(t('Read-only account cannot sign events'))
+      default:
+        throw new Error(t('Unsupported signer type'))
+    }
+  }
+
   const publishSignedEvent = async (event: Event, options: TPublishOptions = {}) => {
     const relays = await client.determineTargetRelays(event, options)
     await client.publishEvent(relays, event)
@@ -926,6 +990,7 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
         startLogin: () => setOpenLoginDialog(true),
         checkLogin,
         signEvent,
+        buildSignerForAccount,
         updateRelayListEvent,
         updateProfileEvent,
         updateFollowListEvent,

--- a/src/services/client.service.ts
+++ b/src/services/client.service.ts
@@ -1,4 +1,4 @@
-import { ExtendedKind } from '@/constants'
+import { BIG_RELAY_URLS, ExtendedKind } from '@/constants'
 import { ElectronPool } from '@/lib/electron-pool'
 import {
   compareEvents,
@@ -101,7 +101,7 @@ class ClientService extends EventTarget {
 
   async determineTargetRelays(
     event: NEvent,
-    { specifiedRelayUrls, additionalRelayUrls }: TPublishOptions = {}
+    { specifiedRelayUrls, additionalRelayUrls, isAnonymous }: TPublishOptions = {}
   ) {
     if (event.kind === kinds.Report) {
       const targetEventId = event.tags.find(tagNameEquals('e'))?.[1]
@@ -110,7 +110,11 @@ class ClientService extends EventTarget {
       }
     }
 
-    const defaultRelays = getDefaultRelayUrls()
+    // Anonymous publishes must not be steered to the user's customized default
+    // relays (which may include paid relays with their npub in the URL, or
+    // write relays correlated to their account). Anchor on the generic public
+    // set instead — same names every major Nostr client ships with.
+    const defaultRelays = isAnonymous ? BIG_RELAY_URLS : getDefaultRelayUrls()
     const relaySet = new Set<string>()
     if (specifiedRelayUrls?.length) {
       specifiedRelayUrls.forEach((url) => relaySet.add(url))
@@ -139,8 +143,13 @@ class ClientService extends EventTarget {
         }
       }
 
-      const relayList = await this.fetchRelayList(event.pubkey)
-      relayList.write.forEach((url) => relaySet.add(url))
+      // For anonymous publishes the author is an ephemeral key with no
+      // published relay list — and fetching one would only waste a round trip
+      // and could leak intent. Skip.
+      if (!isAnonymous) {
+        const relayList = await this.fetchRelayList(event.pubkey)
+        relayList.write.forEach((url) => relaySet.add(url))
+      }
 
       if (
         [

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -140,6 +140,14 @@ export type TPublishOptions = {
   specifiedRelayUrls?: string[]
   additionalRelayUrls?: string[]
   minPow?: number
+  /**
+   * Mark this publish as authored by an ephemeral identity (anonymous mode).
+   * When set, the relay resolver falls back to the hardcoded BIG_RELAY_URLS
+   * set instead of the user's customized default relays — which may contain
+   * paid relays with the user's npub baked into the URL or write relays
+   * correlated with their account.
+   */
+  isAnonymous?: boolean
 }
 
 export type TPostTargetItem =


### PR DESCRIPTION
This expands #813 to post as another logged in user. If you browse as Alice but see a post relevant to BobTech, you can reply as BobTech without switching users.

As always, this feature can be plaid with at jumble.nostr.info. Merge much appreciated.