### PR TITLE
Refresh feeds when the browser resumes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { KindFilterProvider } from '@/providers/KindFilterProvider'
 import { MediaUploadServiceProvider } from '@/providers/MediaUploadServiceProvider'
 import { MuteListProvider } from '@/providers/MuteListProvider'
 import { NostrProvider } from '@/providers/NostrProvider'
+import { PageActiveProvider } from '@/providers/PageActiveProvider'
 import { PinListProvider } from '@/providers/PinListProvider'
 import { PinnedUsersProvider } from '@/providers/PinnedUsersProvider'
 import { ScreenSizeProvider } from '@/providers/ScreenSizeProvider'
@@ -57,9 +58,11 @@ export default function App(): JSX.Element {
                                     <FeedProvider>
                                       <MediaUploadServiceProvider>
                                         <KindFilterProvider>
-                                          <PageManager />
-                                          <KeySyncRequestHandler />
-                                          <Toaster />
+                                          <PageActiveProvider>
+                                            <PageManager />
+                                            <KeySyncRequestHandler />
+                                            <Toaster />
+                                          </PageActiveProvider>
                                         </KindFilterProvider>
                                       </MediaUploadServiceProvider>
                                     </FeedProvider>

--- a/src/providers/PageActiveProvider.tsx
+++ b/src/providers/PageActiveProvider.tsx
@@ -1,8 +1,52 @@
-import { createContext, useContext } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
 
 export const PageActiveContext = createContext<boolean | null>(null)
 
+const BrowserActiveContext = createContext(true)
+
+function isBrowserActive() {
+  if (typeof document === 'undefined') return true
+  return document.visibilityState !== 'hidden'
+}
+
+export function PageActiveProvider({ children }: { children: ReactNode }) {
+  const [browserActive, setBrowserActive] = useState(isBrowserActive)
+
+  useEffect(() => {
+    const activate = () => setBrowserActive(isBrowserActive())
+    const deactivate = () => setBrowserActive(false)
+    const handleVisibilityChange = () => setBrowserActive(isBrowserActive())
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    document.addEventListener('resume', activate)
+    document.addEventListener('freeze', deactivate)
+    window.addEventListener('focus', activate)
+    window.addEventListener('online', activate)
+    window.addEventListener('pageshow', activate)
+    window.addEventListener('blur', deactivate)
+    window.addEventListener('offline', deactivate)
+    window.addEventListener('pagehide', deactivate)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      document.removeEventListener('resume', activate)
+      document.removeEventListener('freeze', deactivate)
+      window.removeEventListener('focus', activate)
+      window.removeEventListener('online', activate)
+      window.removeEventListener('pageshow', activate)
+      window.removeEventListener('blur', deactivate)
+      window.removeEventListener('offline', deactivate)
+      window.removeEventListener('pagehide', deactivate)
+    }
+  }, [])
+
+  return (
+    <BrowserActiveContext.Provider value={browserActive}>{children}</BrowserActiveContext.Provider>
+  )
+}
+
 export function usePageActive() {
-  const ctx = useContext(PageActiveContext)
-  return ctx ?? false
+  const pageActive = useContext(PageActiveContext)
+  const browserActive = useContext(BrowserActiveContext)
+  return (pageActive ?? false) && browserActive
 }


### PR DESCRIPTION
Closes #15.

This adds a browser lifecycle layer to the existing page-active signal. The feed components already re-subscribe when `usePageActive()` changes, so the app now treats hidden/sleep/pagehide/offline states as inactive and focus/pageshow/online/resume states as active again. That lets the active feed re-open its timeline subscription and fetch notes newer than the current top item after the browser or notebook wakes up.

Lightning Bounties: issue #15 has a 10,000 sats reward.

Validation:
- `npm run lint`
- `npm test` (26 tests passed)
- `npm run build` (passes; Vite still prints the existing `Invalid URL: wss://` warning)
- Vite dev server smoke check returned HTTP 200 for `/`