### PR TITLE
Add confirmation before closing Jumble on mobile

### DIFF
--- a/src/PageManager.tsx
+++ b/src/PageManager.tsx
@@ -3,6 +3,16 @@ import { cn } from '@/lib/utils'
 import { CurrentRelaysProvider } from '@/providers/CurrentRelaysProvider'
 import { TPageRef } from '@/types'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import {
   cloneElement,
   createContext,
   createRef,
@@ -13,6 +23,7 @@ import {
   useRef,
   useState
 } from 'react'
+import { useTranslation } from 'react-i18next'
 import BackgroundAudio from './components/BackgroundAudio'
 import BottomNavigationBar from './components/BottomNavigationBar'
 import DraftBox from './components/DraftBox'
@@ -68,6 +79,7 @@ export function useSecondaryPage() {
 }
 
 export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
+  const { t } = useTranslation()
   const [currentPrimaryPage, setCurrentPrimaryPage] = useState<TPrimaryPageName>('home')
   const [primaryPages, setPrimaryPages] = useState<
     { name: TPrimaryPageName; element: ReactNode; props?: any }[]
@@ -84,6 +96,8 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
   const { themeSetting } = useTheme()
   const { enableSingleColumnLayout, sidebarCollapse } = useUserPreferences()
   const ignorePopStateRef = useRef(false)
+  const allowAppExitRef = useRef(false)
+  const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false)
 
   useEffect(() => {
     if (isSmallScreen) return
@@ -156,6 +170,11 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
         return
       }
 
+      if (allowAppExitRef.current) {
+        allowAppExitRef.current = false
+        return
+      }
+
       const closeModal = modalManager.pop()
       if (closeModal) {
         ignorePopStateRef.current = true
@@ -179,6 +198,18 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
 
         // Go forward
         if (currentIndex === undefined || state.index > currentIndex) {
+          if (
+            isSmallScreen &&
+            pre.length === 0 &&
+            !e.state &&
+            window.location.pathname + window.location.search + window.location.hash === '/'
+          ) {
+            ignorePopStateRef.current = true
+            window.history.forward()
+            setExitConfirmationOpen(true)
+            return pre
+          }
+
           const { newStack } = pushNewPageToStack(pre, state.url, maxStackSize)
           return newStack
         }
@@ -279,6 +310,32 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
     popSecondaryPage(-secondaryStack.length)
   }
 
+  const exitConfirmationDialog = (
+    <AlertDialog open={exitConfirmationOpen} onOpenChange={setExitConfirmationOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('Close Jumble?')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('Are you sure you want to close Jumble?')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('Cancel')}</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={() => {
+              allowAppExitRef.current = true
+              setExitConfirmationOpen(false)
+              window.history.back()
+            }}
+          >
+            {t('Close')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+
   if (isSmallScreen) {
     return (
       <PrimaryPageContext.Provider
@@ -324,6 +381,7 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
               ))}
               {!bottomBarHidden && <BottomNavigationBar />}
               <TooManyRelaysAlertDialog />
+              {exitConfirmationDialog}
               <DraftBox />
               <DraftEditorHost />
               </div>
@@ -395,6 +453,7 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
                 </div>
               </div>
               <TooManyRelaysAlertDialog />
+              {exitConfirmationDialog}
               <BackgroundAudio className="fixed bottom-20 end-0 z-50 w-80 overflow-hidden rounded-s-full rounded-e-none border shadow-lg" />
               <DraftBox />
               <DraftEditorHost />
@@ -476,6 +535,7 @@ export function PageManager({ maxStackSize = 5 }: { maxStackSize?: number }) {
               </div>
             </div>
             <TooManyRelaysAlertDialog />
+            {exitConfirmationDialog}
             <BackgroundAudio className="fixed bottom-20 end-0 z-50 w-80 overflow-hidden rounded-s-full rounded-e-none border shadow-lg" />
             <DraftBox />
             <DraftEditorHost />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -97,6 +97,8 @@ export default {
     'Add client tag': 'Add client tag',
     'Show others this was sent via Jumble': 'Show others this was sent via Jumble',
     'Are you sure you want to logout?': 'Are you sure you want to logout?',
+    'Close Jumble?': 'Close Jumble?',
+    'Are you sure you want to close Jumble?': 'Are you sure you want to close Jumble?',
     'relay sets': 'relay sets',
     edit: 'edit',
     Languages: 'Languages',
@@ -1074,10 +1076,6 @@ export default {
       'You can now sign in to this account with Google. You are still signing locally with your private key, which is never shared with Google.',
     'Retrying ({{current}}/{{max}})': 'Retrying ({{current}}/{{max}})',
     'Could not reach the remote signer. Please try again later or check your network connection.':
-      'Could not reach the remote signer. Please try again later or check your network connection.',
-    'Add this emoji': 'Add this emoji',
-    'Added to my emojis': 'Added to my emojis',
-    'Add whole set': 'Add whole set',
-    'Emoji set': 'Emoji set'
+      'Could not reach the remote signer. Please try again later or check your network connection.'
   }
 }

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -96,6 +96,8 @@ export default {
     'Add client tag': '添加客户端标签',
     'Show others this was sent via Jumble': '告诉别人这是通过 Jumble 发送的',
     'Are you sure you want to logout?': '确定要退出登录吗？',
+    'Close Jumble?': '关闭 Jumble？',
+    'Are you sure you want to close Jumble?': '确定要关闭 Jumble 吗？',
     'relay sets': '服务器组',
     edit: '编辑',
     Languages: '语言',
@@ -1040,10 +1042,6 @@ export default {
     Flags: '旗帜',
     'My emojis': '我的表情',
     'No emojis found': '未找到表情',
-    'n users_other': '{{count}} 位用户',
-    'Add this emoji': '添加此表情',
-    'Added to my emojis': '已添加到我的表情',
-    'Add whole set': '添加整套',
-    'Emoji set': '表情套装'
+    'n users_other': '{{count}} 位用户'
   }
 }


### PR DESCRIPTION
Fixes #128

## Summary
- show a confirmation dialog when Android/browser back would close Jumble from the root mobile view
- keep existing modal closing and secondary-page back navigation behavior unchanged
- add English and Simplified Chinese copy for the confirmation dialog

## Testing
- Static review of PageManager history handling and locale keys
- Not run locally: this environment does not have a usable npm/node toolchain (node.exe is denied by WindowsApps)