### PR TITLE
fix(editor): separate uploaded media from preceding token

### DIFF
--- a/src/components/PostEditor/PostTextarea/ClipboardAndDropHandler.ts
+++ b/src/components/PostEditor/PostTextarea/ClipboardAndDropHandler.ts
@@ -129,9 +129,28 @@ async function uploadFiles(
 
     const placeholder = `[Uploading "${name}"...]`
     const uploadingNode = view.state.schema.text(placeholder)
-    const hardBreakNode = view.state.schema.nodes.hardBreak.create()
-    let tr = view.state.tr.replaceSelectionWith(uploadingNode)
-    tr = tr.insert(tr.selection.from, hardBreakNode)
+
+    // Separate the media from any preceding content so the inserted URL is not
+    // glued onto the previous token (e.g. a mention or pasted nostr entity),
+    // which would produce malformed content like `nostr:npub1...https://...`.
+    // Skip when already at a boundary: block start, an existing hard break
+    // (e.g. consecutive uploads), or text ending in whitespace.
+    const { $from } = view.state.selection
+    const before = $from.nodeBefore
+    const needsLeadingBreak =
+      $from.parentOffset > 0 &&
+      before != null &&
+      before.type.name !== 'hardBreak' &&
+      !(before.isText && /\s$/.test(before.text ?? ''))
+
+    let tr = view.state.tr
+    if (needsLeadingBreak) {
+      tr = tr.replaceSelectionWith(view.state.schema.nodes.hardBreak.create())
+      tr = tr.insert(tr.selection.from, uploadingNode)
+    } else {
+      tr = tr.replaceSelectionWith(uploadingNode)
+    }
+    tr = tr.insert(tr.selection.from, view.state.schema.nodes.hardBreak.create())
     view.dispatch(tr)
 
     const abortController = abortControllers.get(file)


### PR DESCRIPTION
Uploading an image inserts the URL at the cursor with only a trailing hard break and no leading separator. When media is added right after another token (a mention, a pasted nostr entity, or text with no trailing space), the serialized content glues the URL onto it, e.g. `nostr:npub1...https://...png`. It renders fine in Jumble's regex-based parser but the stored content is malformed for stricter clients.

Insert a leading hard break before the uploaded media unless the cursor is already at a boundary (block start, an existing hard break, or text ending in whitespace), so media lands on its own line. No renderer change.