### PR TITLE
fix(notifications): make Hide-indirect button a clear toggle

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1125,6 +1125,8 @@ export default {
       'This Google account is linked to a different Nostr account',
     'Drop files to upload': 'Drop files to upload',
     'Discover': 'Discover',
-    'Failure reason': 'Failure reason'
+    'Failure reason': 'Failure reason',
+    'Indirect notifications hidden': 'Indirect notifications hidden',
+    'Indirect notifications shown': 'Indirect notifications shown'
   }
 }

--- a/src/pages/primary/NotificationListPage/index.tsx
+++ b/src/pages/primary/NotificationListPage/index.tsx
@@ -9,6 +9,7 @@ import {
 import localStorage from '@/services/local-storage.service'
 import { TPageRef } from '@/types'
 import { BellIcon } from '@phosphor-icons/react'
+import { Eye, EyeOff } from 'lucide-react'
 import { forwardRef, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -54,13 +55,20 @@ function HideUnrelatedNotificationsToggle() {
 
   return (
     <Button
-      variant="ghost"
+      variant={hideIndirect ? 'secondary' : 'ghost'}
+      role="switch"
+      aria-checked={hideIndirect}
+      aria-label={t('Hide indirect')}
+      title={hideIndirect ? t('Indirect notifications hidden') : t('Indirect notifications shown')}
       className={cn(
         'h-10 shrink-0 rounded-xl px-3 [&_svg]:size-5',
-        hideIndirect ? 'bg-muted/40 text-foreground' : 'text-muted-foreground'
+        hideIndirect
+          ? 'ring-1 ring-inset ring-primary/40 text-foreground'
+          : 'text-muted-foreground'
       )}
       onClick={() => updateHideIndirect(!hideIndirect)}
     >
+      {hideIndirect ? <EyeOff /> : <Eye />}
       {t('Hide indirect')}
     </Button>
   )


### PR DESCRIPTION
The button's active state was indistinguishable from its inactive state: muted text with a barely-visible bg-muted/40 in one case, muted text alone in the other. Users couldn't tell whether the filter was on.

- Switch to button variant=secondary when active, ghost when inactive
- Add an inset primary-ring when active for a strong visible state
- Eye / EyeOff icon mirrors the action: an open eye when nothing is being hidden, a closed eye when indirect notifications are being filtered out
- aria-pressed + role="switch" so screen readers report the toggle state
- Tooltip describes the current state in words