### PR TITLE
feat: auto-load new notes when waking from sleep

### DIFF
--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -450,6 +450,16 @@ const NoteList = forwardRef<
       }
     }, [JSON.stringify(subRequests), refreshCount, JSON.stringify(showKinds), active])
 
+    useEffect(() => {
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          setRefreshCount((count) => count + 1)
+        }
+      }
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+      return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }, [])
+
     const handleLoadMore = useCallback(async () => {
       if (!timelineKey || areAlgoRelays) return false
       const newEvents = await client.loadMoreTimeline(


### PR DESCRIPTION
## Description

When you lock your laptop screen and come back hours later, Jumble should automatically load new notes without needing to manually refresh the page.

## Implementation

Added a `visibilitychange` event listener that re-triggers the relay subscription when the browser tab transitions from `hidden` to `visible` (e.g., after OS wake from sleep).

**How it works:**
1. When the browser tab becomes visible again, `setRefreshCount` is incremented
2. This re-runs the existing subscription effect, which closes old connections and opens new ones
3. `sinceRef.current` is already set to the latest known event timestamp + 1, so only **new** events are fetched
4. New events are merged seamlessly into the feed

**Line change:** +10 lines in `src/components/NoteList/index.tsx`. No new dependencies.

## Testing

- Tested manually: verified that `visibilitychange` listener fires correctly when tab becomes visible
- Existing behavior unchanged: the `refresh()` function (which scrolls to top) is kept separate; this auto-trigger only re-subscribes without scrolling

Closes #15
