### PR TITLE
feat(note): preview external content above comments

### DIFF
--- a/src/components/WebPreview/index.tsx
+++ b/src/components/WebPreview/index.tsx
@@ -11,11 +11,17 @@ import { Skeleton } from '../ui/skeleton'
 export default function WebPreview({
   url,
   className,
-  mustLoad
+  mustLoad,
+  fallbackImage
 }: {
   url: string
   className?: string
   mustLoad?: boolean
+  /**
+   * Thumbnail to use when the page exposes no og:image, or when its metadata
+   * can't be fetched at all (no proxy configured, or the site blocks it).
+   */
+  fallbackImage?: string
 }) {
   const { autoLoadMedia } = useContentPolicy()
   const { allowInsecureConnection } = useUserPreferences()
@@ -25,7 +31,8 @@ export default function WebPreview({
     (autoLoadMedia || Boolean(mustLoad)) &&
     (allowInsecureConnection || !isInsecureUrl(url))
   const { metadata, isLoading } = useFetchWebMetadata(url, shouldShow && isNearViewport)
-  const { title, description, image } = metadata
+  const { title, description } = metadata
+  const image = metadata.image || fallbackImage
 
   const { hostname, displayUrl } = useMemo(() => {
     try {

--- a/src/components/YoutubeEmbeddedPlayer/index.tsx
+++ b/src/components/YoutubeEmbeddedPlayer/index.tsx
@@ -45,7 +45,7 @@ export default function YoutubeEmbeddedPlayer({
   return <Player videoId={videoId} isShort={isShort} className={className} />
 }
 
-function parseYoutubeUrl(url: string) {
+export function parseYoutubeUrl(url: string) {
   const patterns = [
     /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
     /youtube\.com\/watch\?.*v=([^&\n?#]+)/,

--- a/src/pages/secondary/NotePage/index.tsx
+++ b/src/pages/secondary/NotePage/index.tsx
@@ -17,6 +17,8 @@ import TranslateButton from '@/components/TranslateButton'
 import TrustScoreBadge from '@/components/TrustScoreBadge'
 import UserAvatar, { UserAvatarSkeleton } from '@/components/UserAvatar'
 import Username from '@/components/Username'
+import WebPreview from '@/components/WebPreview'
+import { parseYoutubeUrl } from '@/components/YoutubeEmbeddedPlayer'
 import { Card } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -248,9 +250,23 @@ export default NotePage
 function ExternalRoot({ value }: { value: string }) {
   const { push } = useSecondaryPage()
   const { autoLoadProfilePicture } = useContentPolicy()
+  // A YouTube thumbnail comes straight from the video id, so it still shows
+  // when og:image isn't reachable.
+  const fallbackImage = useMemo(() => {
+    const { videoId } = parseYoutubeUrl(value)
+    return videoId ? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg` : undefined
+  }, [value])
 
   return (
     <div>
+      {/* Show what the thread is replying to. Always the compact link card,
+          never an inline player or gallery — those grow tall enough (a vertical
+          video especially) to push the note itself off screen. The full embed
+          lives on the external content page. Renders nothing when media
+          auto-load is off, leaving the link below as the fallback. */}
+      {/^https?:\/\//i.test(value) && (
+        <WebPreview className="mb-2" url={value} fallbackImage={fallbackImage} />
+      )}
       <Card
         className="clickable text-muted-foreground hover:text-foreground flex items-center gap-1 px-1.5 py-1 text-sm"
         onClick={() => push(toExternalContent(value))}


### PR DESCRIPTION
A kind-1111 comment whose root is a web URL only showed the raw URL, so the thread gave no indication of what it was replying to. This shows the compact link preview above it.

Always the fixed-height card, never an inline player or gallery — a vertical video embed grows tall enough to push the note itself off screen. The full embed stays on the external content page, one tap away.

`WebPreview` gains an optional `fallbackImage`, so a YouTube thumbnail (derivable from the video id) still shows when `og:image` can't be fetched.

---

@CodyTseng — apologies for slipping this through while you temporarily enabled PR submissions. I'm building a feature in my NIP-07 signing app Sidecar that links to Jumble for web content replies. This improves the UX, and I think it would be the right move for Jumble to include this.