### PR TITLE
fix: sign with the correct account when a NIP-07 extension holds multiple accounts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,6 +64,7 @@ export const StorageKey = {
   PROCESSED_SYNC_REQUEST_IDS: 'processedSyncRequestIds',
   DISABLE_NOTIFICATION_SYNC: 'disableNotificationSync',
   DISMISSED_DESKTOP_APP_TIP: 'dismissedDesktopAppTip',
+  NIP07_CHECK_DISABLED: 'nip07CheckDisabled',
   NOTE_LIST_MODE: 'noteListMode', // deprecated
   ENABLE_LIVE_FEED: 'enableLiveFeed', // deprecated
   HIDE_UNTRUSTED_NOTES: 'hideUntrustedNotes', // deprecated

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1134,6 +1134,9 @@ export default {
     'Anonymous reply hint':
       'Uses a new one-time Nostr identity. Your account will not appear in the event, but relays and network observers may still correlate your activity.',
     'One-time identity': 'One-time identity',
-    'Try loading more': 'Try loading more'
+    'Try loading more': 'Try loading more',
+    'Your signer extension switched to {{username}}': 'Your signer extension switched to {{username}}',
+    'Your signer extension is on a new account': 'Your signer extension is on a new account',
+    'This account is already logged in': 'This account is already logged in'
   }
 }

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1148,6 +1148,9 @@ export default {
     'Anonymous reply hint':
       'Usa uma nova identidade Nostr descartável. Sua conta não aparecerá no evento, mas relays e observadores da rede ainda poderão correlacionar sua atividade.',
     'One-time identity': 'Identidade descartável',
-    'Try loading more': 'Tentar carregar mais'
+    'Try loading more': 'Tentar carregar mais',
+    'Your signer extension switched to {{username}}': 'Sua extensão de assinatura mudou para {{username}}',
+    'Your signer extension is on a new account': 'Sua extensão de assinatura está em uma nova conta',
+    'This account is already logged in': 'Esta conta já está logada'
   }
 }

--- a/src/i18n/locales/pt-PT.ts
+++ b/src/i18n/locales/pt-PT.ts
@@ -1152,6 +1152,9 @@ export default {
     'Anonymous reply hint':
       'Utiliza uma nova identidade Nostr de utilização única. A sua conta não aparecerá no evento, mas os relays e observadores da rede ainda poderão associar a sua atividade.',
     'One-time identity': 'Identidade de utilização única',
-    'Try loading more': 'Tentar carregar mais'
+    'Try loading more': 'Tentar carregar mais',
+    'Your signer extension switched to {{username}}': 'A sua extensão de assinatura mudou para {{username}}',
+    'Your signer extension is on a new account': 'A sua extensão de assinatura está numa nova conta',
+    'This account is already logged in': 'Esta conta já tem sessão iniciada'
   }
 }

--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -45,7 +45,7 @@ import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useDeletedEvent } from '../DeletedEventProvider'
 import { BunkerSigner } from './bunker.signer'
-import { Nip07Signer } from './nip-07.signer'
+import { clearNip07ProviderCache, Nip07Signer, NIP07_PROMPT_THRESHOLD_MS } from './nip-07.signer'
 import { NostrConnectionSigner } from './nostrConnection.signer'
 import { NpubSigner } from './npub.signer'
 import { NsecSigner } from './nsec.signer'
@@ -157,6 +157,12 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     resolve: (password: string) => void
     reject: () => void
   } | null>(null)
+  // Survive account switches: the last pubkey seen active in the NIP-07
+  // extension, and whether its getPublicKey prompts (stop polling if so —
+  // persisted so a prompting extension is probed at most once, not once per
+  // page load).
+  const nip07ExtensionPubkeyRef = useRef<string | null>(null)
+  const nip07CheckDisabledRef = useRef(storage.getNip07CheckDisabled())
 
   useEffect(() => {
     const init = async () => {
@@ -457,6 +463,97 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     }
   }, [account])
 
+  // Multi-account NIP-07 extensions switch the active account globally without
+  // notifying the page. Switching requires leaving the tab, so re-check whenever
+  // it regains focus and offer to switch to (or add) the detected account
+  // instead of failing at the next signature.
+  useEffect(() => {
+    if (account?.signerType !== 'nip-07') return
+
+    let promptedPubkey: string | null = null
+    let checking = false
+    let lastCheckedAt = 0
+    const disableCheck = () => {
+      nip07CheckDisabledRef.current = true
+      storage.setNip07CheckDisabled(true)
+    }
+    const check = async () => {
+      if (checking || nip07CheckDisabledRef.current || document.hidden || !window.nostr) return
+      if (Date.now() - lastCheckedAt < 1500) return
+      lastCheckedAt = Date.now()
+      checking = true
+      const startedAt = Date.now()
+      try {
+        clearNip07ProviderCache(window.nostr)
+        const activePubkey = await window.nostr.getPublicKey()
+        // A slow answer means the extension prompted the user. Polling on
+        // every focus would spam prompts, so stop for good.
+        if (Date.now() - startedAt > NIP07_PROMPT_THRESHOLD_MS) {
+          disableCheck()
+        }
+        const previousPubkey = nip07ExtensionPubkeyRef.current
+        nip07ExtensionPubkeyRef.current = activePubkey
+        if (!activePubkey || activePubkey === account.pubkey) {
+          promptedPubkey = null
+          toast.dismiss('nip07-account-changed')
+          return
+        }
+        // Signing is bound to the session account via the event template, so
+        // a mismatch alone is a normal state for multi-account users. Only
+        // announce actual extension-side switches.
+        if (previousPubkey === activePubkey) return
+        if (promptedPubkey === activePubkey) return
+        promptedPubkey = activePubkey
+        const known = storage
+          .getAccounts()
+          .some((act) => act.signerType === 'nip-07' && act.pubkey === activePubkey)
+        toast.info(
+          known
+            ? t('Your signer extension switched to {{username}}', {
+                username: formatPubkey(activePubkey)
+              })
+            : t('Your signer extension is on a new account'),
+          {
+            id: 'nip07-account-changed',
+            duration: 10_000,
+            action: {
+              label: known ? t('Switch account') : t('Add'),
+              onClick: () => {
+                if (known) {
+                  switchAccount({ pubkey: activePubkey, signerType: 'nip-07' })
+                } else {
+                  nip07Login()
+                }
+              }
+            }
+          }
+        )
+      } catch {
+        // Give up only when the failure involved a visible prompt the user
+        // dismissed; a fast failure is a transient extension hiccup and the
+        // next focus should try again.
+        if (Date.now() - startedAt > NIP07_PROMPT_THRESHOLD_MS) {
+          disableCheck()
+        }
+      } finally {
+        checking = false
+      }
+    }
+
+    if (document.hasFocus()) {
+      check()
+    }
+    window.addEventListener('focus', check)
+    document.addEventListener('visibilitychange', check)
+    return () => {
+      window.removeEventListener('focus', check)
+      document.removeEventListener('visibilitychange', check)
+      // The toast's action closes over this render's account state; acting on
+      // it after logout/switch would be wrong.
+      toast.dismiss('nip07-account-changed')
+    }
+  }, [account])
+
   useEffect(() => {
     customEmojiService.init(userEmojiListEvent)
   }, [userEmojiListEvent])
@@ -579,6 +676,11 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
       if (!pubkey) {
         throw new Error('You did not allow to access your pubkey')
       }
+      // Still call login() to refresh the signer instance (the old one may
+      // hold a dead window.nostr reference after an extension reload).
+      if (account?.pubkey === pubkey && account.signerType === 'nip-07') {
+        toast.info(t('This account is already logged in'))
+      }
       return login(nip07Signer, { pubkey, signerType: 'nip-07' })
     } catch (err) {
       toast.error(t('Login failed') + ': ' + (err as Error).message)
@@ -652,7 +754,7 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
       }
     } else if (account.signerType === 'nip-07') {
       const nip07Signer = new Nip07Signer()
-      await nip07Signer.init()
+      await nip07Signer.init(account.pubkey)
       return login(nip07Signer, account)
     } else if (account.signerType === 'bunker') {
       if (account.bunker && account.bunkerClientSecretKey) {
@@ -698,7 +800,7 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
       }
     } else if (account.signerType === 'nip-07') {
       const nip07Signer = new Nip07Signer()
-      await nip07Signer.init()
+      await nip07Signer.init(account.pubkey)
       return nip07Signer
     } else if (account.signerType === 'bunker') {
       if (account.bunker && account.bunkerClientSecretKey) {

--- a/src/providers/NostrProvider/nip-07.signer.ts
+++ b/src/providers/NostrProvider/nip-07.signer.ts
@@ -1,17 +1,42 @@
+import { pubkeyToNpub } from '@/lib/pubkey'
 import { withSignerApproval } from '@/lib/signer-approval'
 import { ISigner, TDraftEvent, TNip07 } from '@/types'
+import { verifyEvent } from 'nostr-tools'
+
+// A silent getPublicKey answer returns in milliseconds; anything slower means
+// the extension showed a prompt and we should stop proactive checks.
+export const NIP07_PROMPT_THRESHOLD_MS = 1_000
+
+// nos2x-family providers (nostrame included) cache the pubkey on the injected
+// page object and never invalidate it when the active account changes in the
+// extension, so getPublicKey() keeps returning the old account until a page
+// reload. Clearing the cache forces a fresh query to the extension background.
+export function clearNip07ProviderCache(signer: TNip07) {
+  if ('_pubkey' in signer) {
+    try {
+      ;(signer as { _pubkey?: string | null })._pubkey = null
+    } catch {
+      // frozen provider object; nothing we can do
+    }
+  }
+}
 
 export class Nip07Signer implements ISigner {
   private signer: TNip07 | undefined
   private pubkey: string | null = null
+  private extensionPrompts = false
+  private activeAccountCheck: Promise<void> | null = null
 
-  async init() {
+  async init(expectedPubkey?: string) {
     const checkInterval = 100
     const maxAttempts = 50
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       if (window.nostr) {
         this.signer = window.nostr
+        if (expectedPubkey) {
+          this.pubkey = expectedPubkey
+        }
         return
       }
       await new Promise((resolve) => setTimeout(resolve, checkInterval))
@@ -27,16 +52,89 @@ export class Nip07Signer implements ISigner {
       throw new Error('Should call init() first')
     }
     if (!this.pubkey) {
+      clearNip07ProviderCache(this.signer)
       this.pubkey = await this.signer.getPublicKey()
     }
     return this.pubkey
+  }
+
+  // Multi-account extensions (e.g. nostrame) encrypt and decrypt with
+  // whichever account is currently active in the extension, which may not be
+  // the account this signer was bound to. Verify before every operation so we
+  // never use the wrong key. Single-account extensions always return the same
+  // pubkey, so this check is transparent for them.
+  private ensureActiveAccount(signer: TNip07): Promise<void> {
+    if (!this.pubkey || this.extensionPrompts) {
+      return Promise.resolve()
+    }
+    // Concurrent operations (e.g. decrypting several private lists right
+    // after login) share a single check so prompting extensions show at most
+    // one dialog.
+    if (!this.activeAccountCheck) {
+      this.activeAccountCheck = this.checkActiveAccount(signer).finally(() => {
+        this.activeAccountCheck = null
+      })
+    }
+    return this.activeAccountCheck
+  }
+
+  private async checkActiveAccount(signer: TNip07) {
+    clearNip07ProviderCache(signer)
+    const startedAt = Date.now()
+    let activePubkey: string
+    try {
+      activePubkey = await signer.getPublicKey()
+    } catch {
+      // A rejection means the extension showed a prompt the user dismissed.
+      // Re-checking would spam prompts, so let the extension's own
+      // per-operation prompt be the account guard instead of blocking the
+      // operation.
+      this.extensionPrompts = true
+      return
+    }
+    // The extension prompts on every getPublicKey call; checking again would
+    // spam the user, so trust the extension's own per-account prompt instead.
+    if (Date.now() - startedAt > NIP07_PROMPT_THRESHOLD_MS) {
+      this.extensionPrompts = true
+    }
+    if (activePubkey !== this.pubkey) {
+      throw new Error(
+        `Your signer extension is currently on a different account. Please switch it to ${pubkeyToNpub(this.pubkey!)} and try again, or log out if this account is no longer in your extension.`
+      )
+    }
   }
 
   async signEvent(draftEvent: TDraftEvent) {
     if (!this.signer) {
       throw new Error('Should call init() first')
     }
-    return await withSignerApproval(this.signer.signEvent(draftEvent))
+    // Some multi-account extensions (e.g. nostrame) honor a `pubkey` field in
+    // the template and sign with that account even when another one is active.
+    // Extensions using nostr-tools' finalizeEvent overwrite the field, so it
+    // is safe to send either way; the checks below discard wrong results.
+    const draft = this.pubkey ? ({ ...draftEvent, pubkey: this.pubkey } as TDraftEvent) : draftEvent
+    let event
+    try {
+      event = await withSignerApproval(this.signer.signEvent(draft))
+    } catch (err) {
+      // A strict extension may reject the non-standard pubkey field. Retry
+      // with a spec-shaped template, but never after a user denial (that
+      // would show a second approval prompt).
+      const message = err instanceof Error ? err.message : String(err)
+      if (draft === draftEvent || /denied|reject|cancel/i.test(message)) {
+        throw err
+      }
+      event = await withSignerApproval(this.signer.signEvent(draftEvent))
+    }
+    if (event && this.pubkey && event.pubkey !== this.pubkey) {
+      throw new Error(
+        `Your signer extension signed with a different account. Please switch it to ${pubkeyToNpub(this.pubkey)} and try again.`
+      )
+    }
+    if (event && !verifyEvent(event)) {
+      throw new Error('Your signer extension returned an invalid signature')
+    }
+    return event
   }
 
   async nip04Encrypt(pubkey: string, plainText: string) {
@@ -46,6 +144,7 @@ export class Nip07Signer implements ISigner {
     if (!this.signer.nip04?.encrypt) {
       throw new Error('The extension you are using does not support nip04 encryption')
     }
+    await this.ensureActiveAccount(this.signer)
     return await this.signer.nip04.encrypt(pubkey, plainText)
   }
 
@@ -56,6 +155,7 @@ export class Nip07Signer implements ISigner {
     if (!this.signer.nip04?.decrypt) {
       throw new Error('The extension you are using does not support nip04 decryption')
     }
+    await this.ensureActiveAccount(this.signer)
     return await this.signer.nip04.decrypt(pubkey, cipherText)
   }
 
@@ -66,6 +166,7 @@ export class Nip07Signer implements ISigner {
     if (!this.signer.nip44?.encrypt) {
       throw new Error('The extension you are using does not support nip44 encryption')
     }
+    await this.ensureActiveAccount(this.signer)
     return await this.signer.nip44.encrypt(pubkey, plainText)
   }
 
@@ -76,6 +177,7 @@ export class Nip07Signer implements ISigner {
     if (!this.signer.nip44?.decrypt) {
       throw new Error('The extension you are using does not support nip44 decryption')
     }
+    await this.ensureActiveAccount(this.signer)
     return await this.signer.nip44.decrypt(pubkey, cipherText)
   }
 }

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -1121,6 +1121,14 @@ class LocalStorageService {
     window.localStorage.setItem(StorageKey.FAVICON_URL_TEMPLATE, template)
   }
 
+  getNip07CheckDisabled() {
+    return window.localStorage.getItem(StorageKey.NIP07_CHECK_DISABLED) === 'true'
+  }
+
+  setNip07CheckDisabled(disabled: boolean) {
+    window.localStorage.setItem(StorageKey.NIP07_CHECK_DISABLED, disabled.toString())
+  }
+
   getFilterOutOnionRelays() {
     return this.filterOutOnionRelays
   }


### PR DESCRIPTION
## Problem

Multi-account NIP-07 extensions (e.g. [nostrame](https://github.com/getnostrame/nostrame)) operate on whichever account is currently active in the extension. Jumble stored the session pubkey but never verified it against the extension, so after switching accounts in the extension, events were silently signed (and DMs encrypted/decrypted) with the wrong key.

## Changes

- **Bind `Nip07Signer` to the session pubkey.** `signEvent` sends the bound `pubkey` in the event template — extensions that support it (nostrame does) sign with the matching account even when another one is active. The returned event's pubkey and signature are verified (`verifyEvent`), so no extension can produce a wrong-account or invalid event. Strict extensions that reject the non-standard field get one retry with a spec-shaped template (never after a user denial).
- **Verify the active account before nip04/nip44 operations** (encryption has no template mechanism, so the active extension account must match). Concurrent checks are deduped into a single `getPublicKey` call; if the extension prompts on `getPublicKey` (>1s answer or rejection), the pre-check backs off and defers to the extension's own per-operation prompt instead of blocking or spamming.
- **Work around a nos2x-family provider bug:** the injected `window.nostr` caches `_pubkey` on the page and never invalidates it when the active account changes, so `getPublicKey()` returns the old account until reload. The cache is cleared before any query that needs a fresh answer.
- **Detect extension-side account switches on tab focus** and show a toast offering to switch to (or add) the detected account. The probe is throttled, only announces actual extension-side switches (a mismatch alone is a normal state for multi-account users), disables itself persistently for extensions that prompt on `getPublicKey`, and is dismissed on logout/account change so its action never fires with stale state.
- Re-logging in via extension with the already-active account shows an info toast but still refreshes the signer instance (recovers from a dead `window.nostr` reference after an extension reload).

Single-account extensions are unaffected: their pubkey always matches, template `pubkey` is overwritten by `finalizeEvent`-based signers, and the proactive probe stops permanently after the first prompt.

## Test plan

- With nostrame holding 3 accounts: switch accounts in the extension → toast appears on tab refocus offering switch/add; posting always signs with the Jumble session account regardless of the extension's active account; wrong-account crypto operations fail with a clear message instead of using the wrong key.
- With single-account extensions: login, posting, DMs unchanged; no extra prompts after the initial permission grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)