### PR TITLE
chore(deps): update bitcoin-connect to 3.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2874,34 +2874,34 @@
       "license": "MIT"
     },
     "node_modules/@getalby/bitcoin-connect": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@getalby/bitcoin-connect/-/bitcoin-connect-3.12.2.tgz",
-      "integrity": "sha512-qtKKSE7gEVmCyc1AJR5cD9dxD83PvQotG7U7SvERXz1z9fEuKzKpXc16olVZhLiJjTLeQo1P2Zqv0d6lISKhBQ==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@getalby/bitcoin-connect/-/bitcoin-connect-3.12.3.tgz",
+      "integrity": "sha512-2d+tNHBCZBoImKJgZwTUOyK9ypXaTg/hwvtQ8EHbgSKKkuycOrks7SzlUc0iJHthD3JGFVMWZEgOgw4AQVVE4w==",
       "license": "MIT",
       "dependencies": {
-        "@getalby/lightning-tools": "^6.1.0",
-        "@getalby/sdk": "^6.0.2",
-        "@lightninglabs/lnc-web": "^0.3.4-alpha",
+        "@getalby/lightning-tools": "^8.1.1",
+        "@getalby/sdk": "^8.0.3",
+        "@lightninglabs/lnc-web": "^0.3.6-alpha",
         "qrcode-generator": "1.4.4",
-        "zustand": "^4.5.7"
+        "zustand": "^5.0.13"
       }
     },
     "node_modules/@getalby/bitcoin-connect-react": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@getalby/bitcoin-connect-react/-/bitcoin-connect-react-3.12.2.tgz",
-      "integrity": "sha512-kiqr4exrYGEQWlKl1ZiLD6MwR4+b+I6XuZoyjrODeNrgmkJxSJUZsxxTPp0e3Gv5DLF7WBwwCS9MG2YZwSwS8w==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@getalby/bitcoin-connect-react/-/bitcoin-connect-react-3.12.3.tgz",
+      "integrity": "sha512-TflmUi6+BDPyBtSmxpTCCXHLA1oTCK/tesX3z5+Fh44a8pmQO7MxmrAcWIccWF/cPmrkpxciail9DXY8GBnU/Q==",
       "license": "MIT",
       "dependencies": {
-        "@getalby/bitcoin-connect": "^3.12.2"
+        "@getalby/bitcoin-connect": "^3.12.3"
       },
       "peerDependencies": {
         "react": ">=18.2.0"
       }
     },
     "node_modules/@getalby/lightning-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@getalby/lightning-tools/-/lightning-tools-6.1.0.tgz",
-      "integrity": "sha512-rGurar9X4Gm+9xwoNYS8s9YLK7ZYqvbqv4KbHLYV0LEeB0HxZHRgmxblGqg+fYfp6iiYHx+edIgUpt9rS3VwFw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@getalby/lightning-tools/-/lightning-tools-8.2.0.tgz",
+      "integrity": "sha512-eL+cnHyzeUARKVzNRuFBRBppAU5RBJOLjhFVzSWt8hDibRzL5+e4hq8I79+RGHfrWWMUDv382Jx8ewOazrBj7w==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -2912,16 +2912,16 @@
       }
     },
     "node_modules/@getalby/sdk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@getalby/sdk/-/sdk-6.0.2.tgz",
-      "integrity": "sha512-Q7fKMlHXFdbT8w1O+khOVhg4FnPwdB1ltvmeoYI6Ec6RKc4qUVwx6vEM6xl8NumOboUMmA1YO5WDxm6WLTJ52w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@getalby/sdk/-/sdk-8.0.3.tgz",
+      "integrity": "sha512-vPEogAWwLHbL55COeXrRN7yRBXMDGDxX1M2A+o3Lqw60FFng6fa9FK9sw8ptdILMD1dQZq8FzPXuabQ7seoDBA==",
       "license": "MIT",
       "dependencies": {
-        "@getalby/lightning-tools": "^6.0.0",
-        "nostr-tools": "^2.17.0"
+        "@getalby/lightning-tools": "^8.1.1",
+        "nostr-tools": "^2.23.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
       },
       "funding": {
         "type": "lightning",
@@ -3208,18 +3208,18 @@
       }
     },
     "node_modules/@lightninglabs/lnc-core": {
-      "version": "0.3.4-alpha",
-      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.3.4-alpha.tgz",
-      "integrity": "sha512-S/L1gNHqF8jW3DVXBvzVX8zyJO4O2FRfKFNE5U3rtRBaczX+fSVpK3yz/CdgBqhBzyZ+1un6nVZE/tftnfjQwA==",
+      "version": "0.3.6-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.3.6-alpha.tgz",
+      "integrity": "sha512-ObzY5wi+PS0GQduFHYDjGJpYZxKD27vtMf3fUVne2gGNMej1mvvJAOwATgef8YV/IZodAzy73Z/F2zfaQ+iE4Q==",
       "license": "MIT"
     },
     "node_modules/@lightninglabs/lnc-web": {
-      "version": "0.3.4-alpha",
-      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.3.4-alpha.tgz",
-      "integrity": "sha512-ARTsCm71ewJ3sWaW4DEauEXr9wG4qPpCMWGGVjbjvvo5Jvd3svLO610JLYoV7LvQhyW6dKLlAooLxYws2y9FLA==",
+      "version": "0.3.6-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.3.6-alpha.tgz",
+      "integrity": "sha512-oiL1mKlbEjb1lcmNAHA0Gn+mlx5oQOJ8YVONJR/vgo4QLmL/48EyA12QbZ71mP9li45hGOoGqpYMRwBYtIeFog==",
       "license": "MIT",
       "dependencies": {
-        "@lightninglabs/lnc-core": "0.3.4-alpha",
+        "@lightninglabs/lnc-core": "^0.3.6-alpha",
         "crypto-js": "4.2.0"
       }
     },
@@ -19020,20 +19020,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -19043,6 +19041,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }


### PR DESCRIPTION
Jumble pins `@getalby/bitcoin-connect` at 3.12.2, which still lists Primal in the connect modal. Primal's mobile wallet moved to the Spark protocol and no longer supports persistent NWC connections — pairing appears to succeed, but later operations fail. The connector was removed upstream in getAlby/bitcoin-connect#383 and released in 3.12.3.

`package.json` already permits 3.12.3 via `^3.12.2`, so only the lockfile changes. Transitive bumps, all within the Alby/LNC subtree: `@getalby/sdk` 6.0.2 → 8.0.3, `@getalby/lightning-tools` 6.1.0 → 8.2.0, `@lightninglabs/lnc-core` 0.3.4-alpha → 0.3.6-alpha. `nostr-tools` is unaffected.

Verified: typecheck, lint, build and tests pass, and the connect modal no longer lists Primal.