### PR TITLE
fix: sync follow list across tabs

### DIFF
--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -398,6 +398,39 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     }
   }, [account])
 
+  // Keep the follow list (kind:3 contacts) in sync across tabs and clients.
+  // Following/unfollowing in another Jumble tab (or any other Nostr client)
+  // publishes a new kind:3 event. Subscribing to the current account's
+  // contacts events lets this tab apply the latest follow list live, without
+  // needing a refresh. (issue #112)
+  useEffect(() => {
+    if (!account) return
+
+    const defaultRelays = getDefaultRelayUrls()
+    const relays =
+      relayList?.write.concat(defaultRelays).slice(0, 4) ?? defaultRelays.slice(0, 4)
+    const sub = client.subscribe(
+      relays,
+      {
+        kinds: [kinds.Contacts],
+        authors: [account.pubkey]
+      },
+      {
+        onevent: async (event) => {
+          const stored = await indexedDb.putReplaceableEvent(event)
+          if (stored.id !== event.id) return
+
+          setFollowListEvent(event)
+          await client.updateFollowListCache(event)
+        }
+      }
+    )
+
+    return () => {
+      sub.close()
+    }
+  }, [account, relayList])
+
   useEffect(() => {
     if (!account) return
 


### PR DESCRIPTION
close #112

## Problem
Following/unfollowing someone in one Jumble tab (or in any other Nostr client) publishes a new kind:3 (contacts) event, but other open Jumble tabs keep showing the stale follow list until the page is refreshed.

## Fix
In `NostrProvider`, subscribe live to the current account's own kind:3 events (via `client.subscribe`, same relay set used for the initial one-shot fetch: `relayList.write` + default relays). When a newer contacts event arrives:

- it is stored through `indexedDb.putReplaceableEvent` (which keeps the newest version of a replaceable event),
- the `followListEvent` state is updated so `FollowListProvider` re-derives the follow set immediately,
- `client.updateFollowListCache` keeps the follow cache in sync.

The subscription is re-created on account/relay-list changes and closed on unmount. Stale or replayed events are ignored because `putReplaceableEvent` only wins for newer events.

This mirrors the existing patterns already used by `updateFollowListEvent` and the encryption-key service's live subscription.

## Testing
- `npm run build` — passes (typecheck + vite build)
- `npm run lint` — clean