### PR TITLE
fix(editor): don't prefix a bech32 id that belongs to a URL

### DIFF
--- a/src/lib/tiptap.spec.ts
+++ b/src/lib/tiptap.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nip19 } from 'nostr-tools'
+
+// Pulled in transitively by tiptap.ts; it reaches localStorage at module load,
+// which isn't available in the node test environment.
+vi.mock('@/services/custom-emoji.service', () => ({
+  default: { isCustomEmojiId: () => false }
+}))
+
+const { parseEditorJsonToText } = await import('./tiptap')
+
+const PUBKEY = 'ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74'
+const npub = nip19.npubEncode(PUBKEY)
+
+const doc = (text: string) => ({
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+})
+
+describe('parseEditorJsonToText', () => {
+  it('adds the nostr: prefix to a bare mention', () => {
+    expect(parseEditorJsonToText(doc(`gm ${npub}`))).toBe(`gm nostr:${npub}`)
+  })
+
+  it('adds the prefix when the mention starts the note', () => {
+    expect(parseEditorJsonToText(doc(`${npub} gm`))).toBe(`nostr:${npub} gm`)
+  })
+
+  it('keeps an existing prefix without doubling it', () => {
+    expect(parseEditorJsonToText(doc(`gm nostr:${npub}`))).toBe(`gm nostr:${npub}`)
+  })
+
+  it('still prefixes a mention that ends a sentence', () => {
+    expect(parseEditorJsonToText(doc(`gm ${npub}.`))).toBe(`gm nostr:${npub}.`)
+    expect(parseEditorJsonToText(doc(`gm ${npub}. bye`))).toBe(`gm nostr:${npub}. bye`)
+  })
+
+  it('leaves a bech32 that is part of a hostname alone', () => {
+    const url = `${npub}.blossom.band/image.png`
+    expect(parseEditorJsonToText(doc(url))).toBe(url)
+    expect(parseEditorJsonToText(doc(`see ${url} nice`))).toBe(`see ${url} nice`)
+  })
+
+  it('leaves a bech32 that is followed by a path alone', () => {
+    const url = `${npub}/image.png`
+    expect(parseEditorJsonToText(doc(url))).toBe(url)
+  })
+
+  it('does not touch a bech32 inside an absolute URL', () => {
+    const url = `https://${npub}.blossom.band/image.png`
+    expect(parseEditorJsonToText(doc(url))).toBe(url)
+  })
+
+  it('leaves invalid bech32 untouched', () => {
+    expect(parseEditorJsonToText(doc('npub1notrealbech32'))).toBe('npub1notrealbech32')
+  })
+})

--- a/src/lib/tiptap.ts
+++ b/src/lib/tiptap.ts
@@ -7,7 +7,18 @@ export function parseEditorJsonToText(node?: JSONContent, options?: { trim?: boo
   const text = _parseEditorJsonToText(node)
   const regex = /(^|\s+|@)(nostr:)?(nevent|naddr|nprofile|npub)1[a-zA-Z0-9]+/g
 
-  const normalized = text.replace(regex, (match, leadingWhitespace) => {
+  const normalized = text.replace(regex, (...args) => {
+    const [match, leadingWhitespace] = args as [string, string]
+    const offset = args[args.length - 2] as number
+    const full = args[args.length - 1] as string
+
+    // A bech32 id that runs straight into a hostname or a path belongs to a URL
+    // (e.g. npub1….blossom.band/image.png), not to a mention. Prefixing it there
+    // breaks the link, so leave it alone.
+    if (/^(?:\.[a-zA-Z0-9-]|\/)/.test(full.slice(offset + match.length))) {
+      return match
+    }
+
     let bech32 = match.trim()
     const whitespace = leadingWhitespace || ''
 


### PR DESCRIPTION
Closes #830

A scheme-less link whose host starts with a bech32 id — `npub1….blossom.band/image.png` — had `nostr:` inserted in front of the id on publish, which breaks the URL. The published note then renders the id as a mention chip with the rest of the link orphaned as text.

Skips the rewrite when the id runs straight into a hostname or a path. A mention that merely ends a sentence still gets the prefix, since the guard requires a domain character after the dot.

Adds `src/lib/tiptap.spec.ts` — 8 cases. The two URL cases fail without the change; the six regression cases (bare mention, mention at note start, existing prefix, sentence-ending period, absolute URL, invalid bech32) pass either way.