### PR TITLE
feat(content): render references written without the nostr: prefix

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -4,6 +4,8 @@ import {
   EmbeddedEventParser,
   EmbeddedHashtagParser,
   EmbeddedLNInvoiceParser,
+  EmbeddedLegacyEventParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
   EmbeddedWebsocketUrlParser,
@@ -73,6 +75,8 @@ export default function Content({
         EmbeddedUrlParser,
         EmbeddedLNInvoiceParser,
         EmbeddedWebsocketUrlParser,
+        EmbeddedLegacyEventParser,
+        EmbeddedLegacyMentionParser,
         EmbeddedHashtagParser,
         EmbeddedEmojiParser
       ])

--- a/src/components/ContentPreview/Content.tsx
+++ b/src/components/ContentPreview/Content.tsx
@@ -1,6 +1,8 @@
 import {
   EmbeddedEmojiParser,
   EmbeddedEventParser,
+  EmbeddedLegacyEventParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
   parseContent
@@ -27,6 +29,8 @@ export default function Content({
       EmbeddedEventParser,
       EmbeddedMentionParser,
       EmbeddedUrlParser,
+      EmbeddedLegacyEventParser,
+      EmbeddedLegacyMentionParser,
       EmbeddedEmojiParser
     ])
   }, [content])

--- a/src/components/ProfileAbout/index.tsx
+++ b/src/components/ProfileAbout/index.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedEmojiParser,
   EmbeddedHashtagParser,
+  EmbeddedLegacyMentionParser,
   EmbeddedMentionParser,
   EmbeddedUrlParser,
   EmbeddedWebsocketUrlParser,
@@ -42,6 +43,7 @@ export default function ProfileAbout({
       EmbeddedMentionParser,
       EmbeddedWebsocketUrlParser,
       EmbeddedUrlParser,
+      EmbeddedLegacyMentionParser,
       EmbeddedHashtagParser,
       EmbeddedEmojiParser
     ])

--- a/src/lib/content-parser.spec.ts
+++ b/src/lib/content-parser.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { nip19 } from 'nostr-tools'
+import {
+  EmbeddedEventParser,
+  EmbeddedLegacyEventParser,
+  EmbeddedLegacyMentionParser,
+  EmbeddedMentionParser,
+  EmbeddedUrlParser,
+  parseContent
+} from './content-parser'
+
+const PUBKEY = 'ee6ea13ab9fe5c4a68eaf9b1a34fe014a66b40117c50ee2a614f4cda959b6e74'
+const EVENT_ID = 'dc0685a5b90eebbc473d19123550c032c3af596cfcec62927a7c70add5fc8c04'
+const npub = nip19.npubEncode(PUBKEY)
+const nevent = nip19.neventEncode({ id: EVENT_ID })
+const note = nip19.noteEncode(EVENT_ID)
+
+// Mirrors the order used by the renderers: prefixed refs, then URLs, then bare.
+const PARSERS = [
+  EmbeddedEventParser,
+  EmbeddedMentionParser,
+  EmbeddedUrlParser,
+  EmbeddedLegacyEventParser,
+  EmbeddedLegacyMentionParser
+]
+
+const parse = (content: string) => parseContent(content, PARSERS)
+const types = (content: string) => parse(content).map((n) => n.type)
+const find = (content: string, type: string) => parse(content).find((n) => n.type === type)
+
+describe('bare nostr references', () => {
+  it('renders a bare npub as a mention', () => {
+    expect(types(`gm ${npub}`)).toContain('mention')
+  })
+
+  it('renders a bare nevent as an event', () => {
+    expect(types(`look at ${nevent}`)).toContain('event')
+  })
+
+  it('renders a bare note1 as an event', () => {
+    expect(types(`look at ${note}`)).toContain('event')
+  })
+
+  it('normalizes bare refs to the prefixed form so rendering is identical', () => {
+    expect(find(`gm ${npub}`, 'mention')?.data).toBe(`nostr:${npub}`)
+    expect(find(`gm ${nevent}`, 'event')?.data).toBe(`nostr:${nevent}`)
+  })
+
+  it('still handles prefixed refs, without doubling the prefix', () => {
+    expect(find(`gm nostr:${npub}`, 'mention')?.data).toBe(`nostr:${npub}`)
+    expect(find(`gm nostr:${nevent}`, 'event')?.data).toBe(`nostr:${nevent}`)
+  })
+
+  it('keeps surrounding text intact', () => {
+    const nodes = parse(`before ${npub} after`)
+    expect(nodes.map((n) => n.type)).toEqual(['text', 'mention', 'text'])
+    expect(nodes[0].data).toBe('before ')
+    expect(nodes[2].data).toBe(' after')
+  })
+})
+
+describe('references that belong to a URL are left alone', () => {
+  it('does not carve an npub out of an absolute URL', () => {
+    const url = `https://${npub}.blossom.band/image.png`
+    expect(types(url)).not.toContain('mention')
+    // A lone image URL is emitted as a single `images` node; the URL must survive whole.
+    expect(find(url, 'images')?.data).toEqual([url])
+  })
+
+  it('does not carve an npub out of a scheme-less host', () => {
+    const url = `${npub}.blossom.band/image.png`
+    // Not a URL Jumble linkifies, but it must at least stay intact as text.
+    expect(parse(url)).toEqual([{ type: 'text', data: url }])
+  })
+
+  it('does not treat a ref followed by a path as a reference', () => {
+    expect(types(`${npub}/image.png`)).not.toContain('mention')
+  })
+
+  it('does not match a ref glued to a preceding token', () => {
+    expect(types(`x${npub}`)).not.toContain('mention')
+  })
+
+  it('still matches a ref in brackets or quotes', () => {
+    expect(types(`(${npub})`)).toContain('mention')
+    expect(types(`"${nevent}"`)).toContain('event')
+  })
+
+  it('still matches a ref that ends a sentence', () => {
+    expect(types(`gm ${npub}.`)).toContain('mention')
+  })
+})
+
+describe('invalid bech32 is not treated as a reference', () => {
+  it('ignores a malformed npub', () => {
+    const bad = 'npub1' + 'q'.repeat(58)
+    expect(types(`gm ${bad}`)).not.toContain('mention')
+  })
+
+  it('ignores a truncated ref', () => {
+    expect(types(`gm ${npub.slice(0, 30)}`)).not.toContain('mention')
+  })
+})

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -9,6 +9,7 @@ import {
   X_URL_REGEX,
   YOUTUBE_URL_REGEX
 } from '@/constants'
+import { nip19 } from 'nostr-tools'
 import { isImage, isMedia } from './url'
 
 export type TEmbeddedNodeType =
@@ -18,7 +19,6 @@ export type TEmbeddedNodeType =
   | 'media'
   | 'event'
   | 'mention'
-  | 'legacy-mention'
   | 'hashtag'
   | 'websocket-url'
   | 'url'
@@ -51,10 +51,65 @@ export const EmbeddedMentionParser: TContentParser = {
   regex: EMBEDDED_MENTION_REGEX
 }
 
-export const EmbeddedLegacyMentionParser: TContentParser = {
-  type: 'legacy-mention',
-  regex: /npub1[a-z0-9]{58}|nprofile1[a-z0-9]+/g
+// Some clients publish references without the `nostr:` prefix. These parsers
+// pick those up so they render like any other reference instead of as a wall of
+// bech32. They must run after EmbeddedUrlParser, so that a reference inside a
+// link has already been claimed as a URL.
+const BARE_MENTION_REGEX = /(?:npub1|nprofile1)[023456789acdefghjklmnpqrstuvwxyz]{20,}/g
+const BARE_EVENT_REGEX = /(?:nevent1|note1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]{20,}/g
+
+function createBareReferenceParser(
+  regex: RegExp,
+  type: 'mention' | 'event'
+): (content: string) => TEmbeddedNode[] {
+  return (content: string) => {
+    const result: TEmbeddedNode[] = []
+    let lastIndex = 0
+
+    for (const match of content.matchAll(regex)) {
+      const start = match.index!
+      const end = start + match[0].length
+      const before = start === 0 ? '' : content[start - 1]
+      const after = content.slice(end)
+
+      // Only treat it as a reference when it stands on its own. A bech32 id
+      // wedged between other characters usually belongs to something else —
+      // most often a URL, e.g. npub1….blossom.band/image.png.
+      const isolated = before === '' || /[\s([<"']/.test(before)
+      const runsIntoUrl = /^(?:\.[a-zA-Z0-9-]|\/)/.test(after)
+      if (!isolated || runsIntoUrl) continue
+
+      try {
+        nip19.decode(match[0])
+      } catch {
+        continue
+      }
+
+      if (start > lastIndex) {
+        result.push({ type: 'text', data: content.slice(lastIndex, start) })
+      }
+      // Normalize to the prefixed form so everything downstream — rendering,
+      // layout, block detection — treats it exactly like a prefixed reference.
+      result.push({ type, data: `nostr:${match[0]}` })
+      lastIndex = end
+    }
+
+    if (lastIndex < content.length) {
+      result.push({ type: 'text', data: content.slice(lastIndex) })
+    }
+    return result
+  }
 }
+
+export const EmbeddedLegacyMentionParser: TContentParser = createBareReferenceParser(
+  BARE_MENTION_REGEX,
+  'mention'
+)
+
+export const EmbeddedLegacyEventParser: TContentParser = createBareReferenceParser(
+  BARE_EVENT_REGEX,
+  'event'
+)
 
 export const EmbeddedEventParser: TContentParser = {
   type: 'event',


### PR DESCRIPTION
Closes #850

Some clients publish `npub`/`nprofile`/`nevent`/`note`/`naddr` references without the `nostr:` prefix. Jumble showed them as a wall of raw bech32.

Bare references are normalized to the prefixed form and emitted as the existing `mention`/`event` nodes, so rendering, layout and block detection treat them exactly like a prefixed reference — no renderer branches change.

Guards, in order of effect:

- the parsers run after `EmbeddedUrlParser`, so a reference inside a link is already claimed as a URL
- the reference must stand on its own (start of string, whitespace, or `([<"'`)
- it must not run into a hostname or a path — a scheme-less host never reaches `URL_REGEX`
- candidates are validated with `nip19.decode`, so malformed bech32 stays text

Profile bios opt into mentions only; they have no renderer for embedded events, so emitting them there would print `nostr:nevent1…` as literal text.

`EmbeddedLegacyMentionParser` was dead code (defined, never imported) with no guards — the name is reused for the guarded version, and the now-unused `legacy-mention` node type is dropped.

Adds `src/lib/content-parser.spec.ts` — 14 cases covering bare refs, prefixed refs, URL collisions and invalid bech32.

Independent of #851 (different files); either can merge first.

Verified against:

- `nevent1qvzqqqqqqypzpmnw5yatnljuff5w47d35d87q99xddqpzlzsac4xzn6vm22ekmn5qyghwumn8ghj7mn0wd68ytnhd9hx2tcpzamhxue69uhhyetvv9ujuct60fsk6mewdejhgtcqyp25ujddfxsp7mqpl0c9fjtkwsnm6afj8whs394nxufcz28tjqrpv70fxvv`
- `nevent1qvzqqqqqqypzqak8r2hr5jglrk0wc37t59lz98x6gyf6pwaku6hpwakhvslznjh6qydhwumn8ghj7arjv4hxg6twvuh8yetvv9uhxtnvv9hxgtcpzamhxue69uhhyetvv9ujuurjd9kkzmpwdejhgtcqyq8f550035rgglr6nwslavhazfvh7x5dwqwclwwxj9tgmx52p5t4kf204zg`