### PR TITLE
feat: auto-refresh feed after returning from sleep or long absence

### DIFF
--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -371,6 +371,33 @@ const NoteList = forwardRef<
 
     useImperativeHandle(ref, () => ({ scrollToTop, refresh }), [])
 
+    // Auto-refresh the feed when returning from sleep or after being away for a
+    // long time (e.g. laptop lid closed), so new notes load without a manual reload.
+    const activeRef = useRef(active)
+    activeRef.current = active
+    const lastHiddenAtRef = useRef<number | undefined>(undefined)
+    useEffect(() => {
+      const AUTO_REFRESH_HIDDEN_THRESHOLD = 5 * 60 * 1000
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') {
+          lastHiddenAtRef.current = Date.now()
+          return
+        }
+        const hiddenAt = lastHiddenAtRef.current
+        lastHiddenAtRef.current = undefined
+        if (
+          hiddenAt &&
+          Date.now() - hiddenAt > AUTO_REFRESH_HIDDEN_THRESHOLD &&
+          document.visibilityState === 'visible' &&
+          activeRef.current
+        ) {
+          refresh()
+        }
+      }
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+    }, [])
+
     useEffect(() => {
       if (!subRequests.length) return
 


### PR DESCRIPTION
Closes #15

When a laptop wakes from sleep (or the tab becomes visible again after being hidden for over 5 minutes), the feed now automatically refreshes so new notes load without a manual page reload.

- Adds a `visibilitychange` listener to `NoteList`
- Only triggers when the page was hidden longer than 5 minutes and the list belongs to the active page, so normal tab switching is unaffected
- Reuses the existing `refresh()` flow, keeping behavior consistent with pull-to-refresh