### PR TITLE
feat: hide like and zap buttons on own notes

### DIFF
--- a/src/components/StuffStats/index.tsx
+++ b/src/components/StuffStats/index.tsx
@@ -35,6 +35,8 @@ export default function StuffStats({
   const { pubkey } = useNostr()
   const [loading, setLoading] = useState(false)
   const { event } = useStuff(stuff)
+  // Avoid accidentally liking or zapping our own content
+  const isOwnStuff = !!event && !!pubkey && event.pubkey === pubkey
 
   useEffect(() => {
     if (!fetchIfNotExisting) return
@@ -68,8 +70,8 @@ export default function StuffStats({
         >
           <ReplyButton stuff={stuff} />
           <RepostButton stuff={stuff} />
-          <LikeButton stuff={stuff} />
-          <ZapButton stuff={stuff} />
+          {!isOwnStuff && <LikeButton stuff={stuff} />}
+          {!isOwnStuff && <ZapButton stuff={stuff} />}
           <SeenOnButton stuff={stuff} />
         </div>
       </div>
@@ -96,8 +98,8 @@ export default function StuffStats({
         <div className={cn('flex items-center', loading ? 'animate-pulse' : '')}>
           <ReplyButton stuff={stuff} />
           <RepostButton stuff={stuff} />
-          <LikeButton stuff={stuff} />
-          <ZapButton stuff={stuff} />
+          {!isOwnStuff && <LikeButton stuff={stuff} />}
+          {!isOwnStuff && <ZapButton stuff={stuff} />}
         </div>
         <div className="flex items-center">
           <BookmarkButton stuff={stuff} />


### PR DESCRIPTION
Closes #110

Hides the Like and Zap buttons on your own notes (both mobile and desktop layouts) so you can't accidentally like or zap your own content — e.g. when viewing a quote of your note. Stats display is unaffected; the buttons only disappear when the note author is the logged-in user.