### PR TITLE
fix: don't show old notes as new after restoring the app

### DIFF
--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -123,6 +123,11 @@ const NoteList = forwardRef<
         : undefined
     const showNewNotesDirectlyRef = useRef(showNewNotesDirectly)
     showNewNotesDirectlyRef.current = showNewNotesDirectly
+    // Whether the initial timeline population (up to the first EOSE) has
+    // finished. Before that, incoming events belong to the base feed instead
+    // of the "new notes" bucket, otherwise stale notes can show up as "new"
+    // after restoring the app.
+    const initialTimelineLoadedRef = useRef(false)
 
     const pinnedEventHexIdSet = useMemo(() => {
       const set = new Set<string>()
@@ -375,6 +380,7 @@ const NoteList = forwardRef<
       if (!subRequests.length) return
 
       sinceRef.current = undefined
+      initialTimelineLoadedRef.current = false
       setEvents([])
       setStoredEvents([])
       setNewEvents([])
@@ -453,6 +459,14 @@ const NoteList = forwardRef<
 
           if (!recentEvents.length) return
 
+          // The initial population hasn't finished yet, so we can't tell
+          // these events apart from historical ones — add them to the base
+          // timeline instead of showing them as "new".
+          if (!initialTimelineLoadedRef.current && !since) {
+            setEvents((oldEvents) => mergeTimelines([recentEvents, oldEvents]))
+            return
+          }
+
           if (showNewNotesDirectlyRef.current) {
             setEvents((oldEvents) => mergeTimelines([recentEvents, oldEvents]))
           } else {
@@ -485,6 +499,7 @@ const NoteList = forwardRef<
               if (eosed) {
                 threadService.addRepliesToThread(events)
                 setInitialLoading(false)
+                initialTimelineLoadedRef.current = true
               }
             },
             onNew: (event) => {


### PR DESCRIPTION
Closes #270

**Root cause:** when the app restores, the timeline re-initializes with an empty feed state. While the initial population is still in flight (`feedHeadTimestamp` is `undefined`), `partitionIncomingFeedEvents` classifies every incoming event as recent. If the user isn't scrolled to the top during that window (or events arrive before the first batch lands), all those old notes end up in the "new notes" bucket — producing the "99+ new notes" button that only shows old notes.

**Fix:** track whether the initial timeline population has completed (first EOSE). Until then — and only when there's no existing head to compare against — incoming events are merged into the base timeline instead of the "new notes" button. After initialization, behavior is unchanged.

- Reset the flag together with the rest of the timeline state on refresh/subRequest changes
- Set it once the initial subscription reports EOSE