### PR TITLE
fix: show full parent note content in the reply editor

### DIFF
--- a/src/components/PostEditor/ParentEventPreview.tsx
+++ b/src/components/PostEditor/ParentEventPreview.tsx
@@ -57,7 +57,7 @@ export default function ParentEventPreview({
               <div className="whitespace-pre-line italic">{highlightedText}</div>
             </div>
           ) : (
-            <Note size="small" event={parentEvent} hideParentNotePreview />
+            <Note size="small" event={parentEvent} hideParentNotePreview showFull />
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #29

The parent note preview in the reply editor rendered the note in its truncated form, and since the preview container is `pointer-events-none`, the "Show more" control wasn't clickable either — so long parent notes could never be read in full while replying.

Passing `showFull` to the embedded `Note` renders the complete content; the preview box remains capped at `max-h-64` with scroll + fade indicators, so tall notes stay contained.