### PR TITLE
feat: add setting to always use the new notes button

### DIFF
--- a/src/components/NoteList/index.tsx
+++ b/src/components/NoteList/index.tsx
@@ -23,6 +23,7 @@ import { useDeletedEvent } from '@/providers/DeletedEventProvider'
 import { useMuteList } from '@/providers/MuteListProvider'
 import { useNostr } from '@/providers/NostrProvider'
 import { usePageActive } from '@/providers/PageActiveProvider'
+import { useUserPreferences } from '@/providers/UserPreferencesProvider'
 import { useUserTrust } from '@/providers/UserTrustProvider'
 import client from '@/services/client.service'
 import threadService from '@/services/thread.service'
@@ -123,6 +124,9 @@ const NoteList = forwardRef<
         : undefined
     const showNewNotesDirectlyRef = useRef(showNewNotesDirectly)
     showNewNotesDirectlyRef.current = showNewNotesDirectly
+    const { alwaysShowNewNotesButton } = useUserPreferences()
+    const alwaysShowNewNotesButtonRef = useRef(alwaysShowNewNotesButton)
+    alwaysShowNewNotesButtonRef.current = alwaysShowNewNotesButton
 
     const pinnedEventHexIdSet = useMemo(() => {
       const set = new Set<string>()
@@ -462,7 +466,7 @@ const NoteList = forwardRef<
               return rect.top >= 50
             })()
 
-            if (isAtTop) {
+            if (isAtTop && !alwaysShowNewNotesButtonRef.current) {
               setEvents((oldEvents) => mergeTimelines([recentEvents, oldEvents]))
             } else {
               setNewEvents((oldEvents) => mergeTimelines([recentEvents, oldEvents]))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,7 @@ export const StorageKey = {
   BLOSSOM_CACHE_SERVER_ENABLED: 'blossomCacheServerEnabled',
   QUICK_REACTION: 'quickReaction',
   QUICK_REACTION_EMOJI: 'quickReactionEmoji',
+  ALWAYS_SHOW_NEW_NOTES_BUTTON: 'alwaysShowNewNotesButton',
   NSFW_DISPLAY_POLICY: 'nsfwDisplayPolicy',
   DEFAULT_RELAY_URLS: 'defaultRelayUrls',
   MUTED_WORDS: 'mutedWords',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1149,6 +1149,9 @@ export default {
     'Forgot password?': 'Forgot password?',
     'Reset encrypted data': 'Reset encrypted data',
     'Reset encrypted data warning':
-      'If you forgot the password, you can reset the encrypted data. This permanently deletes all stored login sessions and private keys on this device. This cannot be undone.'
+      'If you forgot the password, you can reset the encrypted data. This permanently deletes all stored login sessions and private keys on this device. This cannot be undone.',
+    'Always show the new notes button': 'Always show the new notes button',
+    'New notes are only shown after clicking the button instead of being inserted automatically':
+      'New notes are only shown after clicking the button instead of being inserted automatically'
   }
 }

--- a/src/pages/secondary/GeneralSettingsPage/index.tsx
+++ b/src/pages/secondary/GeneralSettingsPage/index.tsx
@@ -40,6 +40,7 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
   } = useContentPolicy()
   const { quickReaction, updateQuickReaction, quickReactionEmoji, updateQuickReactionEmoji } =
     useUserPreferences()
+  const { alwaysShowNewNotesButton, updateAlwaysShowNewNotesButton } = useUserPreferences()
   const [disableNotificationSync, setDisableNotificationSync] = useState(
     localStorage.getDisableNotificationSync()
   )
@@ -112,6 +113,23 @@ const GeneralSettingsPage = forwardRef(({ index }: { index?: number }, ref) => {
             description={t('Automatically replay videos when they end')}
             control={
               <Switch id="video-loop" checked={videoLoop} onCheckedChange={setVideoLoop} />
+            }
+          />
+        </SettingsGroup>
+
+        <SettingsGroup title={t('Feed')}>
+          <SettingsRow
+            htmlFor="always-show-new-notes-button"
+            title={t('Always show the new notes button')}
+            description={t(
+              'New notes are only shown after clicking the button instead of being inserted automatically'
+            )}
+            control={
+              <Switch
+                id="always-show-new-notes-button"
+                checked={alwaysShowNewNotesButton}
+                onCheckedChange={updateAlwaysShowNewNotesButton}
+              />
             }
           />
         </SettingsGroup>

--- a/src/providers/UserPreferencesProvider.tsx
+++ b/src/providers/UserPreferencesProvider.tsx
@@ -23,6 +23,9 @@ type TUserPreferencesContext = {
   quickReactionEmoji: string | TEmoji
   updateQuickReactionEmoji: (emoji: string | TEmoji) => void
 
+  alwaysShowNewNotesButton: boolean
+  updateAlwaysShowNewNotesButton: (enable: boolean) => void
+
   allowInsecureConnection: boolean
   updateAllowInsecureConnection: (allow: boolean) => void
 
@@ -55,6 +58,9 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
   )
   const [quickReaction, setQuickReaction] = useState(storage.getQuickReaction())
   const [quickReactionEmoji, setQuickReactionEmoji] = useState(storage.getQuickReactionEmoji())
+  const [alwaysShowNewNotesButton, setAlwaysShowNewNotesButton] = useState(
+    storage.getAlwaysShowNewNotesButton()
+  )
 
   const [allowInsecureConnection, setAllowInsecureConnection] = useState(
     storage.getAllowInsecureConnection()
@@ -97,6 +103,11 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
     storage.setQuickReactionEmoji(emoji)
   }
 
+  const updateAlwaysShowNewNotesButton = (enable: boolean) => {
+    setAlwaysShowNewNotesButton(enable)
+    storage.setAlwaysShowNewNotesButton(enable)
+  }
+
   const updateAllowInsecureConnection = (allow: boolean) => {
     setAllowInsecureConnection(allow)
     storage.setAllowInsecureConnection(allow)
@@ -128,6 +139,8 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
         updateQuickReaction,
         quickReactionEmoji,
         updateQuickReactionEmoji,
+        alwaysShowNewNotesButton,
+        updateAlwaysShowNewNotesButton,
         allowInsecureConnection,
         updateAllowInsecureConnection,
         feedTabs,

--- a/src/services/local-storage.service.ts
+++ b/src/services/local-storage.service.ts
@@ -78,6 +78,7 @@ class LocalStorageService {
   private blossomCacheServerEnabled: boolean = false
   private quickReaction: boolean = false
   private quickReactionEmoji: string | TEmoji = '+'
+  private alwaysShowNewNotesButton: boolean = false
   private addClientTag: boolean = false
   private defaultMinPow: number | null = null
   private nsfwDisplayPolicy: TNsfwDisplayPolicy = NSFW_DISPLAY_POLICY.HIDE_CONTENT
@@ -398,6 +399,8 @@ class LocalStorageService {
       window.localStorage.getItem(StorageKey.BLOSSOM_CACHE_SERVER_ENABLED) === 'true'
 
     this.quickReaction = window.localStorage.getItem(StorageKey.QUICK_REACTION) === 'true'
+    this.alwaysShowNewNotesButton =
+      window.localStorage.getItem(StorageKey.ALWAYS_SHOW_NEW_NOTES_BUTTON) === 'true'
     this.addClientTag = window.localStorage.getItem(StorageKey.ADD_CLIENT_TAG) === 'true'
     const defaultMinPowStr = window.localStorage.getItem(StorageKey.DEFAULT_MIN_POW)
     if (defaultMinPowStr !== null) {
@@ -1241,6 +1244,15 @@ class LocalStorageService {
   setQuickReaction(quickReaction: boolean) {
     this.quickReaction = quickReaction
     window.localStorage.setItem(StorageKey.QUICK_REACTION, quickReaction.toString())
+  }
+
+  getAlwaysShowNewNotesButton() {
+    return this.alwaysShowNewNotesButton
+  }
+
+  setAlwaysShowNewNotesButton(enable: boolean) {
+    this.alwaysShowNewNotesButton = enable
+    window.localStorage.setItem(StorageKey.ALWAYS_SHOW_NEW_NOTES_BUTTON, enable.toString())
   }
 
   getAddClientTag() {


### PR DESCRIPTION
Closes #182

Adds an **"Always show the new notes button"** toggle to Settings → General → Feed.

By default Jumble inserts new notes directly into the feed while you're scrolled to the top. With this option enabled, incoming notes always accumulate in the floating "new notes" button (iris.to-style) and are only shown after clicking it — useful if you prefer reading a stable timeline without notes jumping in.

Implementation:
- New persisted user preference (`alwaysShowNewNotesButton`) wired through `local-storage.service` + `UserPreferencesProvider`
- `NoteList` checks the preference before its at-top direct-insert path; `showNewNotesDirectly` behavior is unchanged
- Settings row added under a new "Feed" group, English strings included