### PR TITLE
fix(follow): sync follow list across tabs of the same account

### DIFF
--- a/src/providers/NostrProvider/index.tsx
+++ b/src/providers/NostrProvider/index.tsx
@@ -144,6 +144,11 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
   const [profileEvent, setProfileEvent] = useState<Event | null>(null)
   const [relayList, setRelayList] = useState<TRelayList | null>(null)
   const [followListEvent, setFollowListEvent] = useState<Event | null>(null)
+  // Cross-tab follow-list sync (#112): the latest follow list is mirrored to a
+  // ref (for stale-closure-free comparisons in the broadcast listener) and a
+  // BroadcastChannel is used to notify sibling tabs of the same account.
+  const followListEventRef = useRef<Event | null>(null)
+  const followListChannelRef = useRef<BroadcastChannel | null>(null)
   const [muteListEvent, setMuteListEvent] = useState<Event | null>(null)
   const [pinnedUsersEvent, setPinnedUsersEvent] = useState<Event | null>(null)
   const [bookmarkListEvent, setBookmarkListEvent] = useState<Event | null>(null)
@@ -889,7 +894,45 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
 
     setFollowListEvent(newFollowListEvent)
     await client.updateFollowListCache(newFollowListEvent)
+
+    // Let sibling tabs of the same account pick up the change without a reload.
+    followListChannelRef.current?.postMessage(newFollowListEvent)
   }
+
+  // Keep this tab's follow list in step with follow/unfollow actions taken in
+  // other tabs of the same account (#112). The new kind-3 event is already
+  // persisted to the shared IndexedDB store; broadcasting it lets the in-memory
+  // React state — which drives the follow buttons — update in sibling tabs too,
+  // instead of staying stale until the page is refreshed.
+  useEffect(() => {
+    followListEventRef.current = followListEvent
+  }, [followListEvent])
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return
+
+    const channel = new BroadcastChannel('jumble:follow-list-event')
+    followListChannelRef.current = channel
+
+    channel.onmessage = (e: MessageEvent<Event>) => {
+      const incoming = e.data
+      // Ignore updates for a different account, and never move backwards in
+      // time: replaceable events are ordered by created_at.
+      if (!incoming || !account || incoming.pubkey !== account.pubkey) return
+      const current = followListEventRef.current
+      if (current && current.created_at >= incoming.created_at) return
+
+      setFollowListEvent(incoming)
+      void client.updateFollowListCache(incoming)
+    }
+
+    return () => {
+      channel.close()
+      if (followListChannelRef.current === channel) {
+        followListChannelRef.current = null
+      }
+    }
+  }, [account])
 
   const updateMuteListEvent = async (muteListEvent: Event, privateTags: string[][]) => {
     const newMuteListEvent = await indexedDb.putReplaceableEvent(muteListEvent)


### PR DESCRIPTION
## What

Closes #112 — a follow/unfollow made in one tab now shows up in other tabs of the **same account** without a manual refresh.

## Why

`follow`/`unfollow` publish a new `kind 3` (contacts) event and store it via `indexedDb.putReplaceableEvent`. IndexedDB is shared across tabs, but each tab keeps its own in-memory copy in `NostrProvider` (`followListEvent`), and nothing tells the other tabs it changed — so their follow buttons stayed stale until reload (exactly the report in #112).

## How

In `NostrProvider`:

- After `updateFollowListEvent` stores the new event, it posts it on a `BroadcastChannel('jumble:follow-list-event')`.
- A listener applies incoming events to `followListEvent` state and the in-memory follow-list cache.

It's deliberately conservative:

- **Account-scoped** — an incoming event is ignored unless `event.pubkey === account.pubkey`, so a follow in a tab logged into account A never leaks into a tab on account B.
- **Monotonic** — ignored if not newer than the current event (`created_at`), so replaceable-event ordering is preserved and it never moves the list backwards.
- **Stale-closure-free** — the current follow list is read through a ref, and the channel is re-created on account switch.
- **Feature-detected** — a no-op where `BroadcastChannel` is unavailable; no behavior change there.

+43 / −0, one file, no new dependencies.

## Testing note

I verified the logic by reading through the provider's follow-list flow, but I was **not able to run the app with two tabs locally in my environment** — I'd appreciate a quick check of the two-tab follow/unfollow behavior before merge. The change is additive and guarded, so it can't affect single-tab behavior or other accounts.
